### PR TITLE
Add page 6 question layout and toggle logic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -232,13 +232,19 @@
     display: block;
 }
 
-.page1-next-text {
+.page1-next-text,
+.page2-next-text,
+.page3-next-text,
+.page4-next-text,
+.page5-next-text,
+.page6-next-text {
     position: absolute;
-    left: 42.1333%;
-    top: 8.4507%;
+    left: 42.133333%;
+    top: 8.450704%;
     max-width: none;
     pointer-events: none;
     z-index: 1;
+    display: block;
 }
 
 .page-nav {
@@ -458,17 +464,7 @@
     display: block;
 }
 
-.page2-next-text {
-    position: absolute;
-    left: 42.133333%;
-    top: 8.450704%;
-    width: 15.466667%;
-    height: 42.253521%;
-    max-width: none;
-    pointer-events: none;
-    z-index: 1;
-    display: block;
-}
+
 
 .page2-gender-toggle-btn:focus-visible {
     outline: 2px solid #fff;
@@ -591,17 +587,7 @@
     height: 100%;
     display: block;
 }
-.page3-next-text {
-    position: absolute;
-    left: 42.133333%;
-    top: 8.450704%;
-    width: 15.466667%;
-    height: 42.253521%;
-    max-width: none;
-    pointer-events: none;
-    z-index: 1;
-    display: block;
-}
+
 
 .page4 {
     position: relative;
@@ -722,17 +708,7 @@
     height: 100%;
     display: block;
 }
-.page4-next-text {
-    position: absolute;
-    left: 42.133333%;
-    top: 8.450704%;
-    width: 15.466667%;
-    height: 42.253521%;
-    max-width: none;
-    pointer-events: none;
-    z-index: 1;
-    display: block;
-}
+
 
 .page5 {
     position: relative;
@@ -762,9 +738,7 @@
 .page5-q3-options {
     position: absolute;
     left: 6.133333%;
-    top: 32.512315%;
     width: 86.133333%;
-    height: 47.900986%;
 }
 .page5-q3-option-wrapper {
     position: absolute;
@@ -830,17 +804,110 @@
     height: 100%;
     display: block;
 }
-.page5-next-text {
+
+.page6 {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: block;
+    padding: 0;
+}
+.page6-q4-title {
     position: absolute;
-    left: 42.133333%;
-    top: 8.450704%;
-    width: 15.466667%;
-    height: 42.253521%;
+    left: 7.733333%;
+    top: 12.192118%;
+    width: 18.933333%;
+    height: auto;
     max-width: none;
-    pointer-events: none;
-    z-index: 1;
     display: block;
 }
+.page6-q4-text {
+    position: absolute;
+    left: 8.266667%;
+    top: 20.935961%;
+    width: 85.066667%;
+    height: auto;
+    max-width: none;
+    display: block;
+}
+.page6-q4-options {
+    position: absolute;
+    left: 6.133333%;
+    top: 32.512315%;
+    width: 86.133333%;
+    height: 46.305419%;
+}
+.page6-q4-option {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 15.957447%;
+}
+.page6-q4-option-button {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: block;
+    cursor: pointer;
+}
+.page6-q4-option-button:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+.page6-q4-option-button:disabled {
+    cursor: default;
+}
+.page6-q4-toggle {
+    position: absolute;
+    left: 0;
+    top: 30%;
+    width: 7.430341%;
+    height: auto;
+    max-width: none;
+    display: block;
+    pointer-events: none;
+}
+.page6-q4-label {
+    position: absolute;
+    left: 14.241486%;
+    top: 0;
+    width: 85.758514%;
+    height: 100%;
+    max-width: none;
+    display: block;
+    pointer-events: none;
+}
+.page6-before-btn {
+    position: absolute;
+    left: 5.333333%;
+    top: 86.82266%;
+    width: 22.133333%;
+    height: 3.325123%;
+    display: block;
+}
+.page6-before-btn-img {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+.page6-next-btn {
+    position: absolute;
+    left: 0;
+    top: 91.256158%;
+    width: 100%;
+    height: 8.743842%;
+    display: block;
+}
+.page6-next-btn-img {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
 
 .arrow-button,
 .img-btn {

--- a/src/App.js
+++ b/src/App.js
@@ -217,6 +217,76 @@ const Q3_TOGGLE_IMAGE_SIZE = Q2_TOGGLE_IMAGE_SIZE;
 const Q3_LABEL_LEFT_PERCENT = Q2_LABEL_LEFT_PERCENT;
 const Q3_LABEL_WIDTH_PERCENT = Q2_LABEL_WIDTH_PERCENT;
 const Q3_TOGGLE_WIDTH_PERCENT = Q2_TOGGLE_WIDTH_PERCENT;
+const Q3_OPTIONS_BOUNDARIES = (() => {
+    if (Q3_OPTIONS.length === 0) {
+        return {
+            top: 0,
+            height: Q3_STAGE_HEIGHT,
+        };
+    }
+
+    let minTop = Q3_OPTIONS[0].top;
+    let maxBottom = Q3_OPTIONS[0].top + Q3_OPTIONS[0].height;
+
+    for (const option of Q3_OPTIONS) {
+        if (option.top < minTop) {
+            minTop = option.top;
+        }
+        const optionBottom = option.top + option.height;
+        if (optionBottom > maxBottom) {
+            maxBottom = optionBottom;
+        }
+    }
+
+    const computedHeight = maxBottom - minTop;
+
+    if (computedHeight <= 0) {
+        return { top: 0, height: Q3_STAGE_HEIGHT };
+    }
+
+    return { top: minTop, height: computedHeight };
+})();
+const Q3_OPTIONS_CONTAINER_STAGE_TOP = Q3_OPTIONS_BOUNDARIES.top;
+const Q3_OPTIONS_CONTAINER_STAGE_HEIGHT = Q3_OPTIONS_BOUNDARIES.height;
+const Q3_OPTIONS_CONTAINER_TOP_PERCENT =
+    (Q3_OPTIONS_CONTAINER_STAGE_TOP / Q3_STAGE_HEIGHT) * 100;
+const Q3_OPTIONS_CONTAINER_HEIGHT_PERCENT =
+    (Q3_OPTIONS_CONTAINER_STAGE_HEIGHT / Q3_STAGE_HEIGHT) * 100;
+const Q4_TITLE_SOURCES = ["/q4_title_image.png"];
+const Q4_TEXT_SOURCES = ["/q4_text_image.png"];
+const Q4_OPTIONS = [
+    {
+        id: "definitelyYes",
+        label: "Definitely yes",
+        imageSources: ["/definitely_yes.png"],
+        top: 0,
+    },
+    {
+        id: "probablyWilling",
+        label: "Probably willing",
+        imageSources: ["/probably_willing.png"],
+        top: 74,
+    },
+    {
+        id: "notSure",
+        label: "Not sure",
+        imageSources: ["/not_sure.png"],
+        top: 148,
+    },
+    {
+        id: "no",
+        label: "No",
+        imageSources: ["/no.png"],
+        top: 242,
+    },
+    {
+        id: "iDontKnow",
+        label: "I don't know",
+        imageSources: ["/i_dont.png"],
+        top: 316,
+    },
+];
+const Q4_OPTIONS_CONTAINER_HEIGHT = 376;
 
 function ImgWithFallback({ sources = [], alt, ...imgProps }) {
     const [activeIndex, setActiveIndex] = useState(0);
@@ -264,6 +334,7 @@ export default function App() {
     const [q2Answer, setQ2Answer] = useState(null);
     const [q2OtherText, setQ2OtherText] = useState("");
     const [q3Answer, setQ3Answer] = useState(null);
+    const [q4Answer, setQ4Answer] = useState(null);
     const genderOptionCount = GENDER_OPTIONS.length;
     const genderOptionRefs = useRef([]);
     const q1OptionCount = Q1_OPTIONS.length;
@@ -272,6 +343,8 @@ export default function App() {
     const q2OptionRefs = useRef([]);
     const q3OptionCount = Q3_OPTIONS.length;
     const q3OptionRefs = useRef([]);
+    const q4OptionCount = Q4_OPTIONS.length;
+    const q4OptionRefs = useRef([]);
     const q2OtherInputRef = useRef(null);
     const focusGenderOption = useCallback(
         (index) => {
@@ -308,6 +381,15 @@ export default function App() {
             }
         },
         [q3OptionRefs]
+    );
+    const focusQ4Option = useCallback(
+        (index) => {
+            const target = q4OptionRefs.current[index];
+            if (target) {
+                target.focus();
+            }
+        },
+        [q4OptionRefs]
     );
     const handleGenderKeyDown = useCallback(
         (event, optionIndex) => {
@@ -441,12 +523,43 @@ export default function App() {
         },
         [focusQ3Option, q3OptionCount]
     );
+    const handleQ4KeyDown = useCallback(
+        (event, optionIndex) => {
+            if (q4OptionCount <= 0) {
+                return;
+            }
+
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                event.preventDefault();
+                const nextIndex = (optionIndex + 1) % q4OptionCount;
+                setQ4Answer(Q4_OPTIONS[nextIndex].id);
+                focusQ4Option(nextIndex);
+            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                event.preventDefault();
+                const previousIndex =
+                    (optionIndex - 1 + q4OptionCount) % q4OptionCount;
+                setQ4Answer(Q4_OPTIONS[previousIndex].id);
+                focusQ4Option(previousIndex);
+            } else if (event.key === "Home") {
+                event.preventDefault();
+                setQ4Answer(Q4_OPTIONS[0].id);
+                focusQ4Option(0);
+            } else if (event.key === "End") {
+                event.preventDefault();
+                const lastIndex = q4OptionCount - 1;
+                setQ4Answer(Q4_OPTIONS[lastIndex].id);
+                focusQ4Option(lastIndex);
+            }
+        },
+        [focusQ4Option, q4OptionCount]
+    );
     const ageStopCount = AGE_STOPS.length;
     const canAdvanceFromPage1 = email.trim().length > 0;
     const canAdvanceFromPage2 = ageInteracted && gender !== null;
     const canAdvanceFromPage3 = q1Answer !== null;
     const canAdvanceFromPage4 = q2Answer !== null;
     const canAdvanceFromPage5 = q3Answer !== null;
+    const canAdvanceFromPage6 = q4Answer !== null;
     const handleAgeChange = useCallback((event) => {
         setAgeIndex(Number(event.target.value));
         setAgeInteracted(true);
@@ -466,6 +579,9 @@ export default function App() {
     useEffect(() => {
         q3OptionRefs.current = q3OptionRefs.current.slice(0, q3OptionCount);
     }, [q3OptionCount]);
+    useEffect(() => {
+        q4OptionRefs.current = q4OptionRefs.current.slice(0, q4OptionCount);
+    }, [q4OptionCount]);
     const selectedAgeStop = AGE_STOPS[ageIndex] ?? null;
     const ageHandlePosition = useMemo(() => {
         if (ageStopCount <= 1) {
@@ -510,6 +626,9 @@ export default function App() {
         }
         if (page === 5) {
             return bg3;
+        }
+        if (page === 6) {
+            return bg4;
         }
         return bg1;
     }, [bg0, bg1, bg2, bg3, bg4, page]);
@@ -1073,6 +1192,10 @@ export default function App() {
                             className="page5-q3-options"
                             role="radiogroup"
                             aria-label="관심 있는 카테고리 선택"
+                            style={{
+                                top: `${Q3_OPTIONS_CONTAINER_TOP_PERCENT}%`,
+                                height: `${Q3_OPTIONS_CONTAINER_HEIGHT_PERCENT}%`,
+                            }}
                         >
                             {Q3_OPTIONS.map((option, index) => {
                                 const isSelected = q3Answer === option.id;
@@ -1082,17 +1205,35 @@ export default function App() {
                                 const isTabStop =
                                     q3Answer === null ? index === 0 : isSelected;
                                 const topPercent =
-                                    (option.top / Q3_STAGE_HEIGHT) * 100;
+                                    Q3_OPTIONS_CONTAINER_STAGE_HEIGHT > 0
+                                        ? ((option.top -
+                                              Q3_OPTIONS_CONTAINER_STAGE_TOP) /
+                                              Q3_OPTIONS_CONTAINER_STAGE_HEIGHT) *
+                                          100
+                                        : 0;
                                 const heightPercent =
-                                    (option.height / Q3_STAGE_HEIGHT) * 100;
+                                    Q3_OPTIONS_CONTAINER_STAGE_HEIGHT > 0
+                                        ? (option.height /
+                                              Q3_OPTIONS_CONTAINER_STAGE_HEIGHT) *
+                                          100
+                                        : 0;
                                 const toggleTopPercent =
-                                    (option.toggleTop / option.height) * 100;
+                                    option.height > 0
+                                        ? (option.toggleTop / option.height) * 100
+                                        : 0;
                                 const toggleHeightPercent =
-                                    (Q3_TOGGLE_IMAGE_SIZE / option.height) * 100;
+                                    option.height > 0
+                                        ? (Q3_TOGGLE_IMAGE_SIZE / option.height) *
+                                          100
+                                        : 0;
                                 const labelTopPercent =
-                                    (option.labelTop / option.height) * 100;
+                                    option.height > 0
+                                        ? (option.labelTop / option.height) * 100
+                                        : 0;
                                 const labelHeightPercent =
-                                    (option.labelHeight / option.height) * 100;
+                                    option.height > 0
+                                        ? (option.labelHeight / option.height) * 100
+                                        : 0;
 
                                 return (
                                     <div
@@ -1164,7 +1305,7 @@ export default function App() {
                             type="button"
                             onClick={() => {
                                 if (canAdvanceFromPage5) {
-                                    // 다음 단계는 이후 작업에서 구현 예정
+                                    setPage(6);
                                 }
                             }}
                             aria-label="다음 페이지"
@@ -1186,6 +1327,133 @@ export default function App() {
                             />
                             <ImgWithFallback
                                 className="page5-next-text"
+                                sources={NEXT_TEXT_SOURCES}
+                                alt=""
+                                aria-hidden="true"
+                            />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (page === 6) {
+        return (
+            <div className="app-root">
+                <div
+                    className="phone-stage"
+                    style={{
+                        backgroundImage: `url(${bgUrl})`,
+                    }}
+                >
+                    <div className="page page6">
+                        <ImgWithFallback
+                            className="page6-q4-title"
+                            sources={Q4_TITLE_SOURCES}
+                            alt="질문 4 제목"
+                        />
+                        <ImgWithFallback
+                            className="page6-q4-text"
+                            sources={Q4_TEXT_SOURCES}
+                            alt="질문 4 안내"
+                        />
+                        <div
+                            className="page6-q4-options"
+                            role="radiogroup"
+                            aria-label="추가 참여 의향 선택"
+                        >
+                            {Q4_OPTIONS.map((option, index) => {
+                                const isSelected = q4Answer === option.id;
+                                const toggleSources = isSelected
+                                    ? ON_TOGGLE_SOURCES
+                                    : OFF_TOGGLE_SOURCES;
+                                const isTabStop =
+                                    q4Answer === null ? index === 0 : isSelected;
+                                const topPercent =
+                                    Q4_OPTIONS_CONTAINER_HEIGHT > 0
+                                        ? (option.top / Q4_OPTIONS_CONTAINER_HEIGHT) *
+                                          100
+                                        : 0;
+
+                                return (
+                                    <div
+                                        key={option.id}
+                                        className="page6-q4-option"
+                                        style={{ top: `${topPercent}%` }}
+                                    >
+                                        <button
+                                            type="button"
+                                            className="page6-q4-option-button"
+                                            onClick={() => setQ4Answer(option.id)}
+                                            onKeyDown={(event) =>
+                                                handleQ4KeyDown(event, index)
+                                            }
+                                            role="radio"
+                                            aria-checked={isSelected}
+                                            tabIndex={isTabStop ? 0 : -1}
+                                            ref={(element) => {
+                                                q4OptionRefs.current[index] = element;
+                                            }}
+                                        >
+                                            <span className="sr-only">{option.label}</span>
+                                            <ImgWithFallback
+                                                className="page6-q4-toggle"
+                                                sources={toggleSources}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <ImgWithFallback
+                                                className="page6-q4-label"
+                                                sources={option.imageSources}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                        </button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                        <button
+                            className="img-btn page6-before-btn"
+                            type="button"
+                            onClick={() => setPage(5)}
+                            aria-label="이전 페이지"
+                            title="이전 페이지로 돌아가기"
+                        >
+                            <ImgWithFallback
+                                className="page6-before-btn-img"
+                                sources={BEFORE_BUTTON_SOURCES}
+                                alt="이전"
+                            />
+                        </button>
+                        <button
+                            className="img-btn page6-next-btn"
+                            type="button"
+                            onClick={() => {
+                                if (canAdvanceFromPage6) {
+                                    // 다음 단계는 이후 작업에서 구현 예정
+                                }
+                            }}
+                            aria-label="다음 페이지"
+                            title={
+                                canAdvanceFromPage6
+                                    ? "다음 페이지로 이동"
+                                    : "선택지를 고르면 다음으로 이동할 수 있습니다"
+                            }
+                            disabled={!canAdvanceFromPage6}
+                        >
+                            <ImgWithFallback
+                                className="page6-next-btn-img"
+                                sources={
+                                    canAdvanceFromPage6
+                                        ? NEXT_ON_BUTTON_SOURCES
+                                        : NEXT_OFF_BUTTON_SOURCES
+                                }
+                                alt="다음"
+                            />
+                            <ImgWithFallback
+                                className="page6-next-text"
                                 sources={NEXT_TEXT_SOURCES}
                                 alt=""
                                 aria-hidden="true"


### PR DESCRIPTION
## Summary
- add question 4 assets and radio-style answer state management for the new sixth page
- wire the page 5 next button and background selection to reach the new layout
- style the page 6 imagery and controls using the provided design coordinates

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d33d3c2e98832285672f4230c2990c