### PR TITLE
Add question 5 survey page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -237,7 +237,8 @@
 .page3-next-text,
 .page4-next-text,
 .page5-next-text,
-.page6-next-text {
+.page6-next-text,
+.page7-next-text {
     position: absolute;
     left: 42.133333%;
     top: 8.450704%;
@@ -903,6 +904,122 @@
     display: block;
 }
 .page6-next-btn-img {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.page7 {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: block;
+    padding: 0;
+}
+
+.page7-q5-title {
+    position: absolute;
+    left: 7.733333%;
+    top: 12.192118%;
+    width: 18.933333%;
+    height: auto;
+    max-width: none;
+    display: block;
+}
+
+.page7-q5-text {
+    position: absolute;
+    left: 8.266667%;
+    top: 20.935961%;
+    width: 85.066667%;
+    height: auto;
+    max-width: none;
+    display: block;
+}
+
+.page7-q5-options {
+    position: absolute;
+    left: 6.133333%;
+    top: 32.512315%;
+    width: 86.133333%;
+    height: 46.305419%;
+}
+
+.page7-q5-option {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 15.957447%;
+}
+
+.page7-q5-option-button {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: block;
+    cursor: pointer;
+}
+
+.page7-q5-option-button:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+
+.page7-q5-option-button:disabled {
+    cursor: default;
+}
+
+.page7-q5-toggle {
+    position: absolute;
+    left: 0;
+    top: 30%;
+    width: 7.430341%;
+    height: auto;
+    max-width: none;
+    display: block;
+    pointer-events: none;
+}
+
+.page7-q5-label {
+    position: absolute;
+    left: 14.241486%;
+    top: 0;
+    width: 85.758514%;
+    height: 100%;
+    max-width: none;
+    display: block;
+    pointer-events: none;
+}
+
+.page7-before-btn {
+    position: absolute;
+    left: 5.333333%;
+    top: 86.82266%;
+    width: 22.133333%;
+    height: 3.325123%;
+    display: block;
+}
+
+.page7-before-btn-img {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.page7-next-btn {
+    position: absolute;
+    left: 0;
+    top: 91.256158%;
+    width: 100%;
+    height: 8.743842%;
+    display: block;
+}
+
+.page7-next-btn-img {
     width: 100%;
     height: 100%;
     display: block;

--- a/src/App.js
+++ b/src/App.js
@@ -287,6 +287,41 @@ const Q4_OPTIONS = [
     },
 ];
 const Q4_OPTIONS_CONTAINER_HEIGHT = 376;
+const Q5_TITLE_SOURCES = ["/q5_title_image.png"];
+const Q5_TEXT_SOURCES = ["/q5_text_image.png"];
+const Q5_OPTIONS = [
+    {
+        id: "expensiveEquipment",
+        label: "Expensive equipment",
+        imageSources: ["/expensive_equipment.png"],
+        top: 0,
+    },
+    {
+        id: "complicatedProductionProcess",
+        label: "Complicated production process",
+        imageSources: ["/complicated_production_process.png"],
+        top: 82,
+    },
+    {
+        id: "lackOfTechnicalSkills",
+        label: "Lack of technical skills",
+        imageSources: ["/lack_of_technical_skills.png"],
+        top: 164,
+    },
+    {
+        id: "makingItUnique",
+        label: "Making it unique",
+        imageSources: ["/making_it_unique.png"],
+        top: 246,
+    },
+    {
+        id: "tooMuchEffort",
+        label: "Too much effort",
+        imageSources: ["/too_much_effort.png"],
+        top: 328,
+    },
+];
+const Q5_OPTIONS_CONTAINER_HEIGHT = 376;
 
 function ImgWithFallback({ sources = [], alt, ...imgProps }) {
     const [activeIndex, setActiveIndex] = useState(0);
@@ -335,6 +370,7 @@ export default function App() {
     const [q2OtherText, setQ2OtherText] = useState("");
     const [q3Answer, setQ3Answer] = useState(null);
     const [q4Answer, setQ4Answer] = useState(null);
+    const [q5Answer, setQ5Answer] = useState(null);
     const genderOptionCount = GENDER_OPTIONS.length;
     const genderOptionRefs = useRef([]);
     const q1OptionCount = Q1_OPTIONS.length;
@@ -345,6 +381,8 @@ export default function App() {
     const q3OptionRefs = useRef([]);
     const q4OptionCount = Q4_OPTIONS.length;
     const q4OptionRefs = useRef([]);
+    const q5OptionCount = Q5_OPTIONS.length;
+    const q5OptionRefs = useRef([]);
     const q2OtherInputRef = useRef(null);
     const focusGenderOption = useCallback(
         (index) => {
@@ -390,6 +428,15 @@ export default function App() {
             }
         },
         [q4OptionRefs]
+    );
+    const focusQ5Option = useCallback(
+        (index) => {
+            const target = q5OptionRefs.current[index];
+            if (target) {
+                target.focus();
+            }
+        },
+        [q5OptionRefs]
     );
     const handleGenderKeyDown = useCallback(
         (event, optionIndex) => {
@@ -553,6 +600,36 @@ export default function App() {
         },
         [focusQ4Option, q4OptionCount]
     );
+    const handleQ5KeyDown = useCallback(
+        (event, optionIndex) => {
+            if (q5OptionCount <= 0) {
+                return;
+            }
+
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                event.preventDefault();
+                const nextIndex = (optionIndex + 1) % q5OptionCount;
+                setQ5Answer(Q5_OPTIONS[nextIndex].id);
+                focusQ5Option(nextIndex);
+            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                event.preventDefault();
+                const previousIndex =
+                    (optionIndex - 1 + q5OptionCount) % q5OptionCount;
+                setQ5Answer(Q5_OPTIONS[previousIndex].id);
+                focusQ5Option(previousIndex);
+            } else if (event.key === "Home") {
+                event.preventDefault();
+                setQ5Answer(Q5_OPTIONS[0].id);
+                focusQ5Option(0);
+            } else if (event.key === "End") {
+                event.preventDefault();
+                const lastIndex = q5OptionCount - 1;
+                setQ5Answer(Q5_OPTIONS[lastIndex].id);
+                focusQ5Option(lastIndex);
+            }
+        },
+        [focusQ5Option, q5OptionCount]
+    );
     const ageStopCount = AGE_STOPS.length;
     const canAdvanceFromPage1 = email.trim().length > 0;
     const canAdvanceFromPage2 = ageInteracted && gender !== null;
@@ -560,6 +637,7 @@ export default function App() {
     const canAdvanceFromPage4 = q2Answer !== null;
     const canAdvanceFromPage5 = q3Answer !== null;
     const canAdvanceFromPage6 = q4Answer !== null;
+    const canAdvanceFromPage7 = q5Answer !== null;
     const handleAgeChange = useCallback((event) => {
         setAgeIndex(Number(event.target.value));
         setAgeInteracted(true);
@@ -582,6 +660,9 @@ export default function App() {
     useEffect(() => {
         q4OptionRefs.current = q4OptionRefs.current.slice(0, q4OptionCount);
     }, [q4OptionCount]);
+    useEffect(() => {
+        q5OptionRefs.current = q5OptionRefs.current.slice(0, q5OptionCount);
+    }, [q5OptionCount]);
     const selectedAgeStop = AGE_STOPS[ageIndex] ?? null;
     const ageHandlePosition = useMemo(() => {
         if (ageStopCount <= 1) {
@@ -627,7 +708,7 @@ export default function App() {
         if (page === 5) {
             return bg3;
         }
-        if (page === 6) {
+        if (page === 6 || page === 7) {
             return bg4;
         }
         return bg1;
@@ -1432,7 +1513,7 @@ export default function App() {
                             type="button"
                             onClick={() => {
                                 if (canAdvanceFromPage6) {
-                                    // 다음 단계는 이후 작업에서 구현 예정
+                                    setPage(7);
                                 }
                             }}
                             aria-label="다음 페이지"
@@ -1454,6 +1535,132 @@ export default function App() {
                             />
                             <ImgWithFallback
                                 className="page6-next-text"
+                                sources={NEXT_TEXT_SOURCES}
+                                alt=""
+                                aria-hidden="true"
+                            />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (page === 7) {
+        return (
+            <div className="app-root">
+                <div
+                    className="phone-stage"
+                    style={{
+                        backgroundImage: `url(${bgUrl})`,
+                    }}
+                >
+                    <div className="page page7">
+                        <ImgWithFallback
+                            className="page7-q5-title"
+                            sources={Q5_TITLE_SOURCES}
+                            alt="질문 5 제목"
+                        />
+                        <ImgWithFallback
+                            className="page7-q5-text"
+                            sources={Q5_TEXT_SOURCES}
+                            alt="질문 5 안내"
+                        />
+                        <div
+                            className="page7-q5-options"
+                            role="radiogroup"
+                            aria-label="창작 시 가장 큰 어려움 선택"
+                        >
+                            {Q5_OPTIONS.map((option, index) => {
+                                const isSelected = q5Answer === option.id;
+                                const toggleSources = isSelected
+                                    ? ON_TOGGLE_SOURCES
+                                    : OFF_TOGGLE_SOURCES;
+                                const isTabStop =
+                                    q5Answer === null ? index === 0 : isSelected;
+                                const topPercent =
+                                    Q5_OPTIONS_CONTAINER_HEIGHT > 0
+                                        ? (option.top / Q5_OPTIONS_CONTAINER_HEIGHT) * 100
+                                        : 0;
+
+                                return (
+                                    <div
+                                        key={option.id}
+                                        className="page7-q5-option"
+                                        style={{ top: `${topPercent}%` }}
+                                    >
+                                        <button
+                                            type="button"
+                                            className="page7-q5-option-button"
+                                            onClick={() => setQ5Answer(option.id)}
+                                            onKeyDown={(event) =>
+                                                handleQ5KeyDown(event, index)
+                                            }
+                                            role="radio"
+                                            aria-checked={isSelected}
+                                            tabIndex={isTabStop ? 0 : -1}
+                                            ref={(element) => {
+                                                q5OptionRefs.current[index] = element;
+                                            }}
+                                        >
+                                            <span className="sr-only">{option.label}</span>
+                                            <ImgWithFallback
+                                                className="page7-q5-toggle"
+                                                sources={toggleSources}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <ImgWithFallback
+                                                className="page7-q5-label"
+                                                sources={option.imageSources}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                        </button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                        <button
+                            className="img-btn page7-before-btn"
+                            type="button"
+                            onClick={() => setPage(6)}
+                            aria-label="이전 페이지"
+                            title="이전 페이지로 돌아가기"
+                        >
+                            <ImgWithFallback
+                                className="page7-before-btn-img"
+                                sources={BEFORE_BUTTON_SOURCES}
+                                alt="이전"
+                            />
+                        </button>
+                        <button
+                            className="img-btn page7-next-btn"
+                            type="button"
+                            onClick={() => {
+                                if (canAdvanceFromPage7) {
+                                    // 다음 단계는 이후 작업에서 구현 예정
+                                }
+                            }}
+                            aria-label="다음 페이지"
+                            title={
+                                canAdvanceFromPage7
+                                    ? "다음 페이지로 이동"
+                                    : "선택지를 고르면 다음으로 이동할 수 있습니다"
+                            }
+                            disabled={!canAdvanceFromPage7}
+                        >
+                            <ImgWithFallback
+                                className="page7-next-btn-img"
+                                sources={
+                                    canAdvanceFromPage7
+                                        ? NEXT_ON_BUTTON_SOURCES
+                                        : NEXT_OFF_BUTTON_SOURCES
+                                }
+                                alt="다음"
+                            />
+                            <ImgWithFallback
+                                className="page7-next-text"
                                 sources={NEXT_TEXT_SOURCES}
                                 alt=""
                                 aria-hidden="true"


### PR DESCRIPTION
## Summary
- add assets and state wiring for the fifth survey question using new images
- build page 7 layout mirroring existing survey flow and hook navigation from page 6
- style the new page to match prior question pages

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d37209851c8322bda8500d6d654b3c