### PR TITLE
Store survey responses in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,82 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## AWS S3 저장소 연동
+
+설문 응답은 백엔드 서버가 AWS S3 버킷에 JSON 파일로 업로드합니다. 각 파일은 설문을 처음 진행할 때 입력한 이메일 주소를 기준으로 `surveys/<이메일>/<타임스탬프>.json` 형식의 경로에 저장되며, 동일한 이메일로 여러 번 참여하면 타임스탬프가 다른 파일이 누적됩니다.
+
+### 1. S3 버킷 및 IAM 권한 준비
+
+1. AWS 콘솔에서 새 S3 버킷을 생성합니다. **모든 퍼블릭 액세스 차단(Block all public access)** 옵션을 유지하고, 버킷 버저닝은 선택 사항입니다.
+2. 다음과 같은 정책으로 IAM 정책을 생성합니다(`YOUR_BUCKET_NAME`은 실제 버킷 이름으로 교체).
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "AllowSurveyUploads",
+         "Effect": "Allow",
+         "Action": [
+           "s3:PutObject"
+         ],
+         "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+       }
+     ]
+   }
+   ```
+
+3. 위 정책을 사용할 IAM 사용자(또는 IAM 역할)를 생성하고 액세스 키를 발급합니다. 임시 자격 증명을 사용한다면 세션 토큰도 함께 받아둡니다.
+
+### 2. 환경 변수 설정
+
+루트 디렉터리에 `.env` 파일을 생성하여 아래 값을 채워 주세요. (CI 또는 운영 환경에서는 시스템 환경 변수로 동일한 키를 설정하면 됩니다.)
+
+```
+AWS_ACCESS_KEY_ID=발급받은_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY=발급받은_SECRET_KEY
+AWS_REGION=ap-northeast-2
+AWS_S3_BUCKET_NAME=YOUR_BUCKET_NAME
+# 선택 사항: 버킷 내부에서 사용할 경로 접두사. 기본값은 "surveys"
+AWS_S3_PREFIX=surveys
+# CRA 개발 서버와 백엔드를 동시에 실행할 때는 3001을 권장
+PORT=3001
+# 임시 자격 증명 사용 시에만 필요
+# AWS_SESSION_TOKEN=세션_토큰
+```
+
+### 3. 로컬 실행 방법
+
+1. 의존성을 설치합니다: `npm install`
+2. 프런트엔드 개발용: `npm start`를 실행하면 `package.json`의 `proxy` 설정 덕분에 `/api/*` 요청이 `http://localhost:3001`로 전달됩니다. 별도의 터미널에서 `npm run build` 후 `PORT=3001 node server.js`를 실행하여 백엔드를 띄워 주세요.
+3. 운영용 번들 제공: `npm run build` 이후 `PORT=3000 node server.js`와 같이 원하는 포트로 서버를 실행하면 정적 파일과 API가 함께 서비스됩니다.
+
+### 4. 업로드되는 데이터 구조
+
+서버는 다음과 같은 구조의 JSON을 S3에 기록합니다.
+
+```json
+{
+  "email": "user@example.com",
+  "initialEmail": "user@example.com",
+  "latestEmail": "user@example.com",
+  "responses": {
+    "age": "20s",
+    "ageLabel": "20대",
+    "gender": "female",
+    "q1": "superFun",
+    "q2": "interactivity",
+    "q2OtherText": null,
+    "q3": "fashion",
+    "q4": "definitelyYes",
+    "q5": "tooMuchEffort"
+  },
+  "storedAt": "2025-09-24T05:40:09.091Z"
+}
+```
+
+`responses.q2OtherText`는 "기타" 항목을 선택하고 직접 입력했을 때만 문자열을 포함하며, 그렇지 않으면 `null`로 저장됩니다.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "dotenv": "^10.0.0",
+        "express": "^4.21.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "dotenv": "^10.0.0",
+    "express": "^4.21.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
@@ -18,6 +20,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/server.js
+++ b/server.js
@@ -1,15 +1,349 @@
-﻿const express = require("express");
 const path = require("path");
+const https = require("https");
+const { createHash, createHmac } = require("crypto");
+
+// Load environment variables from a local .env file when present. This keeps
+// the server configuration flexible for local development while still allowing
+// production environments to provide variables through their own mechanisms.
+try {
+    // eslint-disable-next-line global-require
+    require("dotenv").config();
+} catch (error) {
+    // dotenv is optional at runtime; environments that already provide the
+    // variables do not need it. Swallow the error to avoid crashing if the
+    // dependency is not installed when the file is required in other contexts
+    // (for example, during `npm run build`).
+}
+
+const express = require("express");
 
 const app = express();
-const PORT = 3000;
+const PORT = Number.parseInt(process.env.PORT, 10) || 3000;
 
-app.use(express.static(path.join(__dirname, "build")));
+// Ensure JSON bodies are parsed for API routes. The payload is small, so the
+// default 1MB limit is more than enough.
+app.use(express.json());
+
+// Serve the production build of the React application.
+const buildDirectory = path.join(__dirname, "build");
+app.use(express.static(buildDirectory));
+
+const awsConfig = {
+    bucket: process.env.AWS_S3_BUCKET_NAME,
+    region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
+    keyPrefix: process.env.AWS_S3_PREFIX || "surveys",
+};
+
+const RESPONSE_KEYS = [
+    "age",
+    "ageLabel",
+    "gender",
+    "q1",
+    "q2",
+    "q2OtherText",
+    "q3",
+    "q4",
+    "q5",
+];
+
+// Keep the email sanitiser deterministic so follow-up submissions map to the
+// same S3 prefix without introducing subtle differences between builds.
+function sanitizeEmailForKey(email) {
+    return email.toLowerCase().replace(/[^a-z0-9@._-]/g, "-");
+}
+
+function normalisePrefix(prefix) {
+    if (!prefix) {
+        return "";
+    }
+
+    const trimmed = prefix.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (!trimmed) {
+        return "";
+    }
+
+    return `${trimmed}/`;
+}
+
+function buildSurveyObjectKey(email, prefix, date = new Date()) {
+    const safeEmail = sanitizeEmailForKey(email);
+    const timestamp = date.toISOString().replace(/[:.]/g, "-");
+    const normalisedPrefix = normalisePrefix(prefix);
+    return `${normalisedPrefix}${safeEmail}/${timestamp}.json`;
+}
+
+function encodeRFC3986(component) {
+    return encodeURIComponent(component).replace(/[*'()]/g, (character) =>
+        `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+    );
+}
+
+function encodeS3Key(key) {
+    return key
+        .split("/")
+        .map((segment) => encodeRFC3986(segment))
+        .join("/");
+}
+
+function hashSha256(value) {
+    return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function sign(key, message) {
+    return createHmac("sha256", key).update(message, "utf8").digest();
+}
+
+function getSignatureKey(secretAccessKey, dateStamp, regionName, serviceName) {
+    const kDate = sign(`AWS4${secretAccessKey}`, dateStamp);
+    const kRegion = sign(kDate, regionName);
+    const kService = sign(kRegion, serviceName);
+    return sign(kService, "aws4_request");
+}
+
+function buildCanonicalHeaders(headers) {
+    const canonicalEntries = Object.entries(headers)
+        .filter(([, value]) => value !== undefined && value !== null)
+        .map(([key, value]) => [
+            key.toLowerCase(),
+            String(value).trim().replace(/\s+/g, " "),
+        ])
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+    const canonicalHeaders = canonicalEntries
+        .map(([key, value]) => `${key}:${value}\n`)
+        .join("");
+    const signedHeaders = canonicalEntries.map(([key]) => key).join(";");
+
+    return { canonicalHeaders, signedHeaders };
+}
+
+function uploadJsonToS3({
+    bucket,
+    region,
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    key,
+    body,
+}) {
+    return new Promise((resolve, reject) => {
+        if (!bucket || !region || !accessKeyId || !secretAccessKey) {
+            reject(new Error("Incomplete AWS S3 configuration."));
+            return;
+        }
+
+        const host = `${bucket}.s3.${region}.amazonaws.com`;
+        const encodedKey = encodeS3Key(key);
+        const method = "PUT";
+        const service = "s3";
+        const contentType = "application/json";
+        const payloadHash = hashSha256(body);
+
+        const now = new Date();
+        const amzDate = now
+            .toISOString()
+            .replace(/[-:]/g, "")
+            .replace(/\.\d{3}/, "");
+        const dateStamp = amzDate.slice(0, 8);
+
+        const headersForSigning = {
+            host,
+            "content-type": contentType,
+            "x-amz-content-sha256": payloadHash,
+            "x-amz-date": amzDate,
+        };
+
+        if (sessionToken) {
+            headersForSigning["x-amz-security-token"] = sessionToken;
+        }
+
+        const { canonicalHeaders, signedHeaders } = buildCanonicalHeaders(
+            headersForSigning
+        );
+
+        const canonicalRequest = [
+            method,
+            `/${encodedKey}`,
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            payloadHash,
+        ].join("\n");
+
+        const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+        const stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            credentialScope,
+            hashSha256(canonicalRequest),
+        ].join("\n");
+
+        const signingKey = getSignatureKey(
+            secretAccessKey,
+            dateStamp,
+            region,
+            service
+        );
+        const signature = createHmac("sha256", signingKey)
+            .update(stringToSign, "utf8")
+            .digest("hex");
+
+        const authorizationHeader =
+            `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+            `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+        const requestHeaders = {
+            "Content-Type": contentType,
+            "Content-Length": Buffer.byteLength(body),
+            "X-Amz-Content-Sha256": payloadHash,
+            "X-Amz-Date": amzDate,
+            Authorization: authorizationHeader,
+        };
+
+        if (sessionToken) {
+            requestHeaders["X-Amz-Security-Token"] = sessionToken;
+        }
+
+        const requestOptions = {
+            method,
+            hostname: host,
+            path: `/${encodedKey}`,
+            headers: requestHeaders,
+        };
+
+        const request = https.request(requestOptions, (response) => {
+            let responseBody = "";
+            response.setEncoding("utf8");
+            response.on("data", (chunk) => {
+                responseBody += chunk;
+            });
+            response.on("end", () => {
+                if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+                    resolve();
+                } else {
+                    const error = new Error(
+                        `S3 upload failed with status code ${response.statusCode}`
+                    );
+                    error.statusCode = response.statusCode;
+                    error.response = responseBody;
+                    reject(error);
+                }
+            });
+        });
+
+        request.on("error", (error) => {
+            reject(error);
+        });
+
+        request.write(body);
+        request.end();
+    });
+}
+
+function sanitiseResponses(responses) {
+    const cleaned = {};
+    for (const key of RESPONSE_KEYS) {
+        if (!(key in responses)) {
+            cleaned[key] = null;
+            continue;
+        }
+
+        const value = responses[key];
+        if (value === null || value === undefined) {
+            cleaned[key] = null;
+        } else if (typeof value === "string") {
+            const trimmed = value.trim();
+            cleaned[key] = trimmed.length > 0 ? trimmed : null;
+        } else {
+            cleaned[key] = value;
+        }
+    }
+
+    return cleaned;
+}
+
+app.post("/api/surveys", async (req, res) => {
+    const { email, initialEmail, latestEmail, responses } = req.body || {};
+
+    const primaryEmail =
+        typeof initialEmail === "string" && initialEmail.trim().length > 0
+            ? initialEmail.trim()
+            : typeof email === "string" && email.trim().length > 0
+              ? email.trim()
+              : typeof latestEmail === "string" && latestEmail.trim().length > 0
+                ? latestEmail.trim()
+                : "";
+
+    if (!primaryEmail) {
+        res.status(400).json({ error: "이메일 주소가 필요합니다." });
+        return;
+    }
+
+    if (!responses || typeof responses !== "object" || Array.isArray(responses)) {
+        res.status(400).json({ error: "설문 응답 형식이 올바르지 않습니다." });
+        return;
+    }
+
+    if (
+        !awsConfig.bucket ||
+        !awsConfig.region ||
+        !awsConfig.accessKeyId ||
+        !awsConfig.secretAccessKey
+    ) {
+        res.status(500).json({
+            error: "서버의 AWS S3 구성이 완료되지 않았습니다. 환경 변수를 확인해주세요.",
+        });
+        return;
+    }
+
+    const now = new Date();
+    const storedAt = now.toISOString();
+    const latest =
+        typeof latestEmail === "string" && latestEmail.trim().length > 0
+            ? latestEmail.trim()
+            : primaryEmail;
+
+    const record = {
+        email: primaryEmail,
+        initialEmail: primaryEmail,
+        latestEmail: latest,
+        responses: sanitiseResponses(responses),
+        storedAt,
+    };
+
+    const objectKey = buildSurveyObjectKey(primaryEmail, awsConfig.keyPrefix, now);
+    const body = `${JSON.stringify(record, null, 2)}\n`;
+
+    try {
+        await uploadJsonToS3({
+            bucket: awsConfig.bucket,
+            region: awsConfig.region,
+            accessKeyId: awsConfig.accessKeyId,
+            secretAccessKey: awsConfig.secretAccessKey,
+            sessionToken: awsConfig.sessionToken,
+            key: objectKey,
+            body,
+        });
+        res.status(201).json({ success: true });
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to upload survey to S3", error);
+        res.status(502).json({
+            error: "설문 응답을 저장하는 동안 오류가 발생했습니다. 서버 로그를 확인해주세요.",
+        });
+    }
+});
 
 app.get("/", (req, res) => {
-    res.sendFile(path.join(__dirname, "build", "index.html"));
+    res.sendFile(path.join(buildDirectory, "index.html"));
 });
 
 app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
     console.log(`Server running at http://localhost:${PORT}`);
 });
+
+module.exports = app;

--- a/src/App.css
+++ b/src/App.css
@@ -1025,6 +1025,22 @@
     display: block;
 }
 
+.page7-submit-error {
+    position: absolute;
+    left: 10%;
+    right: 10%;
+    bottom: 14%;
+    background: rgba(255, 255, 255, 0.92);
+    color: #b91c1c;
+    font-weight: 600;
+    font-size: clamp(12px, 3vw, 14px);
+    text-align: center;
+    padding: 8px 12px;
+    border-radius: 18px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+    z-index: 2;
+}
+
 
 .page8 {
     position: relative;

--- a/src/App.js
+++ b/src/App.js
@@ -375,6 +375,8 @@ export default function App() {
     const [q3Answer, setQ3Answer] = useState(null);
     const [q4Answer, setQ4Answer] = useState(null);
     const [q5Answer, setQ5Answer] = useState(null);
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState(null);
     const genderOptionCount = GENDER_OPTIONS.length;
     const genderOptionRefs = useRef([]);
     const q1OptionCount = Q1_OPTIONS.length;
@@ -388,6 +390,7 @@ export default function App() {
     const q5OptionCount = Q5_OPTIONS.length;
     const q5OptionRefs = useRef([]);
     const q2OtherInputRef = useRef(null);
+    const initialEmailRef = useRef("");
     const focusGenderOption = useCallback(
         (index) => {
             const target = genderOptionRefs.current[index];
@@ -504,14 +507,18 @@ export default function App() {
     );
     const handleSelectQ2Option = useCallback((optionId, focusInput = false) => {
         setQ2Answer(optionId);
-        if (optionId === "other" && focusInput) {
-            setTimeout(() => {
-                const input = q2OtherInputRef.current;
-                if (input) {
-                    input.focus();
-                    input.select();
-                }
-            }, 0);
+        if (optionId === "other") {
+            if (focusInput) {
+                setTimeout(() => {
+                    const input = q2OtherInputRef.current;
+                    if (input) {
+                        input.focus();
+                        input.select();
+                    }
+                }, 0);
+            }
+        } else {
+            setQ2OtherText("");
         }
     }, []);
     const handleQ2KeyDown = useCallback(
@@ -642,6 +649,19 @@ export default function App() {
     const canAdvanceFromPage5 = q3Answer !== null;
     const canAdvanceFromPage6 = q4Answer !== null;
     const canAdvanceFromPage7 = q5Answer !== null;
+    const handleAdvanceFromPage1 = useCallback(() => {
+        if (!canAdvanceFromPage1) {
+            return;
+        }
+
+        const trimmedEmail = email.trim();
+        if (trimmedEmail.length === 0) {
+            return;
+        }
+
+        initialEmailRef.current = trimmedEmail;
+        setPage(2);
+    }, [canAdvanceFromPage1, email]);
     const handleAgeChange = useCallback((event) => {
         setAgeIndex(Number(event.target.value));
         setAgeInteracted(true);
@@ -667,6 +687,12 @@ export default function App() {
     useEffect(() => {
         q5OptionRefs.current = q5OptionRefs.current.slice(0, q5OptionCount);
     }, [q5OptionCount]);
+    useEffect(() => {
+        if (page !== 7) {
+            setSubmitError(null);
+            setSubmitting(false);
+        }
+    }, [page]);
     const selectedAgeStop = AGE_STOPS[ageIndex] ?? null;
     const ageHandlePosition = useMemo(() => {
         if (ageStopCount <= 1) {
@@ -683,9 +709,95 @@ export default function App() {
         return `calc(${AGE_TRACK_LEFT_PERCENT}% + ${offsetPercent}%)`;
     }, [ageIndex, ageStopCount]);
     const ageValueText = selectedAgeStop ? `${selectedAgeStop.label}` : undefined;
-    const genderValueText = gender
-        ? GENDER_OPTIONS.find((option) => option.id === gender)?.label
-        : undefined;
+    const handleSubmitSurvey = useCallback(async () => {
+        if (!canAdvanceFromPage7 || submitting) {
+            return;
+        }
+
+        const trimmedEmail = email.trim();
+        const capturedEmail =
+            initialEmailRef.current && initialEmailRef.current.trim().length > 0
+                ? initialEmailRef.current
+                : trimmedEmail;
+
+        if (!capturedEmail) {
+            setSubmitError("이메일 정보가 누락되었습니다.");
+            return;
+        }
+
+        setSubmitting(true);
+        setSubmitError(null);
+
+        const trimmedOtherText =
+            q2Answer === "other" ? q2OtherText.trim() : "";
+
+        const payload = {
+            email: capturedEmail,
+            initialEmail:
+                initialEmailRef.current && initialEmailRef.current.trim().length > 0
+                    ? initialEmailRef.current
+                    : capturedEmail,
+            latestEmail: trimmedEmail || capturedEmail,
+            responses: {
+                age: selectedAgeStop ? selectedAgeStop.id : null,
+                ageLabel: selectedAgeStop ? selectedAgeStop.label : null,
+                gender,
+                q1: q1Answer,
+                q2: q2Answer,
+                q2OtherText:
+                    q2Answer === "other" && trimmedOtherText.length > 0
+                        ? trimmedOtherText
+                        : null,
+                q3: q3Answer,
+                q4: q4Answer,
+                q5: q5Answer,
+            },
+        };
+
+        try {
+            const response = await fetch("/api/surveys", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                let message = "설문 저장에 실패했습니다. 잠시 후 다시 시도해주세요.";
+                try {
+                    const errorBody = await response.json();
+                    if (errorBody && typeof errorBody.error === "string") {
+                        message = errorBody.error;
+                    }
+                } catch (parseError) {
+                    // JSON 파싱 실패는 무시합니다.
+                }
+                setSubmitError(message);
+                return;
+            }
+
+            setPage(8);
+        } catch (error) {
+            setSubmitError(
+                "설문을 저장하는 중 오류가 발생했습니다. 네트워크 연결을 확인해주세요."
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    }, [
+        canAdvanceFromPage7,
+        email,
+        gender,
+        q1Answer,
+        q2Answer,
+        q2OtherText,
+        q3Answer,
+        q4Answer,
+        q5Answer,
+        selectedAgeStop,
+        submitting,
+    ]);
 
     // public/ 경로
     const bg0 = useMemo(() => process.env.PUBLIC_URL + "/background0.png", []);
@@ -772,7 +884,7 @@ export default function App() {
                         <button
                             className="img-btn page1-next-btn"
                             type="button"
-                            onClick={() => setPage(2)}
+                            onClick={handleAdvanceFromPage1}
                             aria-label="다음 페이지"
                             title={
                                 canAdvanceFromPage1
@@ -1641,23 +1753,22 @@ export default function App() {
                         <button
                             className="img-btn page7-done-btn"
                             type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage7) {
-                                    setPage(8);
-                                }
-                            }}
+                            onClick={handleSubmitSurvey}
                             aria-label="설문 완료"
                             title={
-                                canAdvanceFromPage7
-                                    ? "설문을 완료합니다"
-                                    : "선택지를 고르면 설문을 완료할 수 있습니다"
+                                submitting
+                                    ? "설문을 저장하는 중입니다"
+                                    : canAdvanceFromPage7
+                                        ? "설문을 완료합니다"
+                                        : "선택지를 고르면 설문을 완료할 수 있습니다"
                             }
-                            disabled={!canAdvanceFromPage7}
+                            aria-busy={submitting ? true : undefined}
+                            disabled={!canAdvanceFromPage7 || submitting}
                         >
                             <ImgWithFallback
                                 className="page7-done-btn-img"
                                 sources={
-                                    canAdvanceFromPage7
+                                    canAdvanceFromPage7 && !submitting
                                         ? DONE_BUTTON_SOURCES
                                         : DONE_OFF_BUTTON_SOURCES
                                 }
@@ -1670,6 +1781,16 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
+                        {submitError ? (
+                            <div className="page7-submit-error" role="alert">
+                                {submitError}
+                            </div>
+                        ) : null}
+                        {submitting ? (
+                            <div className="sr-only" aria-live="polite">
+                                설문을 저장하는 중입니다.
+                            </div>
+                        ) : null}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a backend endpoint that signs AWS requests and uploads survey submissions to S3
- post the client survey data when finishing the flow and surface submission status feedback
- document the AWS setup and proxy/dependency updates required for the integration

## Testing
- npm run build
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3837e8e248322a8eba8d8f291e444