### PR TITLE
Adjust bottom button layout to stay within stage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
+    overflow: hidden;
 }
 
 /* 실제 페이지 콘텐츠는 phone-stage 안에서 배치 */
@@ -1072,6 +1073,18 @@
 
 .arrow-button {
     transition: opacity 220ms ease;
+}
+
+/* 하단 내비게이션 버튼이 배경 밖으로 나가지 않도록 고정 */
+.page1-next-btn,
+.page2-next-btn,
+.page3-next-btn,
+.page4-next-btn,
+.page5-next-btn,
+.page6-next-btn,
+.page7-done-btn {
+    top: auto;
+    bottom: 1.6%;
 }
 
 .arrow-button.is-hidden {


### PR DESCRIPTION
## Summary
- hide overflow on the phone stage container so the background cannot scroll past its bounds
- anchor all Next/Done survey buttons to a consistent bottom offset so they stay fully inside the background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b7a700a88322bd6e67140c4fc04c