### PR TITLE
Align navigation buttons with background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
+    overflow: hidden;
 }
 
 /* 실제 페이지 콘텐츠는 phone-stage 안에서 배치 */
@@ -219,7 +220,7 @@
 .page1-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -453,7 +454,7 @@
 .page2-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -578,7 +579,7 @@
 .page3-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -699,7 +700,7 @@
 .page4-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -795,7 +796,7 @@
 .page5-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -898,7 +899,7 @@
 .page6-next-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -1013,7 +1014,7 @@
 .page7-done-btn {
     position: absolute;
     left: 0;
-    top: 90.763547%;
+    top: 91.256158%;
     width: 100%;
     height: 8.743842%;
     display: block;
@@ -1072,6 +1073,18 @@
 
 .arrow-button {
     transition: opacity 220ms ease;
+}
+
+/* 하단 내비게이션 버튼이 배경 밖으로 나가지 않도록 고정 */
+.page1-next-btn,
+.page2-next-btn,
+.page3-next-btn,
+.page4-next-btn,
+.page5-next-btn,
+.page6-next-btn,
+.page7-done-btn {
+    top: auto;
+    bottom: 0;
 }
 
 .arrow-button.is-hidden {

--- a/src/App.js
+++ b/src/App.js
@@ -293,7 +293,7 @@ const Q4_OPTIONS_CONTAINER_HEIGHT = 376;
 const Q5_TITLE_SOURCES = ["/q5_title_image.png"];
 const Q5_TEXT_SOURCES = ["/q5_text_image.png"];
 const Q5_OPTION_BASE_HEIGHT = 48;
-const Q5_OPTION_GAP = 34;
+const Q5_OPTION_GAP = 22;
 const Q5_DOUBLE_LINE_MULTIPLIER = 1.26;
 const Q5_OPTIONS_WITH_LAYOUT = [
     {


### PR DESCRIPTION
## Summary
- position every page's Next/Done button flush with the background bottom using the design's 741px top alignment
- keep the navigation text overlay centered while ensuring the buttons no longer overlap the Before control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b7a700a88322bd6e67140c4fc04c