### PR TITLE
Keep viewport scale stable when keyboard opens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,12 @@
+:root {
+    --app-viewport-height: 100vh;
+}
+
 /* 뷰포트 전체(레터박스 배경 색) */
 .app-root {
     width: 100vw;
-    height: 100vh;
+    height: var(--app-viewport-height);
+    min-height: var(--app-viewport-height);
     background: #000; /* 검정 레터박스 */
     display: grid;
     place-items: center; /* 중앙 정렬 */
@@ -11,8 +16,11 @@
 .phone-stage {
     /* 디자인 해상도(375x812)에 맞춘 고정 비율 */
     aspect-ratio: 375 / 812;
-    width: min(100vw, calc(100vh * 375 / 812));
-    height: min(100vh, calc(100vw * 812 / 375));
+    width: min(
+        100vw,
+        calc(var(--app-viewport-height) * 375 / 812)
+    );
+    height: min(var(--app-viewport-height), calc(100vw * 812 / 375));
     /* 배경 이미지는 JS에서 설정 */
     background-position: center;
     background-repeat: no-repeat;
@@ -21,7 +29,10 @@
     display: flex;
     flex-direction: column;
     position: relative;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
 }
 
 /* 실제 페이지 콘텐츠는 phone-stage 안에서 배치 */

--- a/src/App.js
+++ b/src/App.js
@@ -350,6 +350,8 @@ const Q5_OPTIONS_CONTAINER_HEIGHT = Q5_OPTIONS.reduce((maxBottom, option) => {
     return bottom > maxBottom ? bottom : maxBottom;
 }, 0);
 const ENDING_IMAGE_SOURCES = ["/ending.png"];
+const VIEWPORT_HEIGHT_EPSILON = 1;
+const KEYBOARD_VISUAL_VIEWPORT_GAP = 120;
 
 function ImgWithFallback({ sources = [], alt, ...imgProps }) {
     const [activeIndex, setActiveIndex] = useState(0);
@@ -413,6 +415,7 @@ export default function App() {
     const q4OptionRefs = useRef([]);
     const q5OptionCount = Q5_OPTIONS.length;
     const q5OptionRefs = useRef([]);
+    const wasKeyboardOpenRef = useRef(false);
     const q2OtherInputRef = useRef(null);
     const initialEmailRef = useRef("");
     const focusGenderOption = useCallback(
@@ -692,6 +695,95 @@ export default function App() {
     }, []);
     const markAgeInteracted = useCallback(() => {
         setAgeInteracted(true);
+    }, []);
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const rootElement = document.documentElement;
+        if (!rootElement) {
+            return;
+        }
+
+        const updateViewportHeight = () => {
+            const { innerHeight, visualViewport } = window;
+            const { clientHeight } = rootElement;
+
+            const candidateHeights = [];
+
+            if (innerHeight > 0 && Number.isFinite(innerHeight)) {
+                candidateHeights.push(innerHeight);
+            }
+
+            if (clientHeight > 0 && Number.isFinite(clientHeight)) {
+                candidateHeights.push(clientHeight);
+            }
+
+            if (candidateHeights.length === 0) {
+                return;
+            }
+
+            const layoutViewportHeight = Math.max(...candidateHeights);
+
+            let isKeyboardOpen = false;
+            if (visualViewport) {
+                const { height } = visualViewport;
+                if (
+                    height > 0 &&
+                    Number.isFinite(height) &&
+                    layoutViewportHeight - height > KEYBOARD_VISUAL_VIEWPORT_GAP
+                ) {
+                    isKeyboardOpen = true;
+                }
+            }
+
+            if (isKeyboardOpen) {
+                wasKeyboardOpenRef.current = true;
+                return;
+            }
+
+            rootElement.style.setProperty(
+                "--app-viewport-height",
+                `${layoutViewportHeight}px`
+            );
+
+            if (
+                wasKeyboardOpenRef.current &&
+                Math.abs(window.scrollY) > VIEWPORT_HEIGHT_EPSILON
+            ) {
+                window.scrollTo(0, 0);
+            }
+
+            wasKeyboardOpenRef.current = false;
+        };
+
+        updateViewportHeight();
+
+        window.addEventListener("resize", updateViewportHeight);
+        window.addEventListener("orientationchange", updateViewportHeight);
+
+        const visualViewport = window.visualViewport;
+        if (visualViewport) {
+            visualViewport.addEventListener("resize", updateViewportHeight);
+            visualViewport.addEventListener("scroll", updateViewportHeight);
+        }
+
+        return () => {
+            window.removeEventListener("resize", updateViewportHeight);
+            window.removeEventListener("orientationchange", updateViewportHeight);
+
+            if (visualViewport) {
+                visualViewport.removeEventListener(
+                    "resize",
+                    updateViewportHeight
+                );
+                visualViewport.removeEventListener(
+                    "scroll",
+                    updateViewportHeight
+                );
+            }
+        };
     }, []);
     useEffect(() => {
         genderOptionRefs.current = genderOptionRefs.current.slice(0, genderOptionCount);


### PR DESCRIPTION
## Summary
- detect on-screen keyboard openings by comparing the layout and visual viewport heights and skip shrinking the viewport-height CSS variable so the stage keeps its scale
- reset scroll only after the keyboard closes while still updating the viewport height when the keyboard is absent

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3cc3de00c83229f6c7fb6cf2b20fe