### PR TITLE
Redesign entry page layout and expand on scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,27 +1,46 @@
+:root {
+    --app-viewport-height: 100vh;
+    --phone-stage-width: 100vw;
+    --phone-stage-height: calc(100vw * 812 / 375);
+}
+
 /* 뷰포트 전체(레터박스 배경 색) */
 .app-root {
     width: 100vw;
-    height: 100vh;
+    height: var(--app-viewport-height);
+    min-height: var(--app-viewport-height);
     background: #000; /* 검정 레터박스 */
-    display: grid;
-    place-items: center; /* 중앙 정렬 */
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 /* “핸드폰 비율(9:16)” 무대 */
 .phone-stage {
-    /* 디자인 해상도(375x812)에 맞춘 고정 비율 */
-    aspect-ratio: 375 / 812;
-    width: min(100vw, calc(100vh * 375 / 812));
-    height: min(100vh, calc(100vw * 812 / 375));
-    /* 배경 이미지는 JS에서 설정 */
+    width: min(var(--phone-stage-width), 100vw);
+    max-width: 100%;
+    height: var(--app-viewport-height);
+    min-height: var(--app-viewport-height);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    position: relative;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
+.phone-stage-inner {
+    width: var(--phone-stage-width);
+    max-width: 100%;
+    height: var(--phone-stage-height);
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    /* 내부 페이지를 레이아웃하기 위한 컨테이너 */
     display: flex;
     flex-direction: column;
     position: relative;
-    overflow: hidden;
 }
 
 /* 실제 페이지 콘텐츠는 phone-stage 안에서 배치 */
@@ -54,23 +73,23 @@
 
 .page0-entry-img-bottom {
     left: 3.2%;
-    width: 93.3333%;
+    width: 99.7333%;
 }
 
 .page0.is-collapsed .page0-entry-img-top {
-    top: 72.3005%;
+    top: 73.7685%;
 }
 
 .page0.is-expanded .page0-entry-img-top {
-    top: 63.5468%;
+    top: 64.6552%;
 }
 
 .page0.is-collapsed .page0-entry-img-bottom {
-    top: 81.2805%;
+    top: 84.9754%;
 }
 
 .page0.is-expanded .page0-entry-img-bottom {
-    top: 72.6601%;
+    top: 75.9852%;
 }
 
 .page0-entry-fade {
@@ -89,11 +108,11 @@
 }
 
 .page0.is-collapsed .page0-entry-fade {
-    top: 81.2805%;
+    top: 84.9754%;
 }
 
 .page0.is-expanded .page0-entry-fade {
-    top: 72.6601%;
+    top: 75.9852%;
     opacity: 0;
 }
 
@@ -105,7 +124,7 @@
 
 .page0 .arrow-button {
     left: 47.7333%;
-    top: 83.2512%;
+    top: 88.0542%;
     width: 4%;
     transition: opacity 220ms ease;
 }
@@ -117,14 +136,14 @@
 
 .page0 .agree-btn {
     left: 39.2%;
-    top: 85.3448%;
+    top: 90.5172%;
     width: 21.6%;
 }
 
 .page0 .start-btn {
-    left: 35.4667%;
-    top: 89.0394%;
-    width: 30.1333%;
+    left: 28%;
+    top: 48.2759%;
+    width: 44%;
 }
 
 .page0 .img-btn img {
@@ -676,23 +695,36 @@
 .page4-q2-other-input {
     position: absolute;
     z-index: 2;
-    background: rgba(255, 255, 255, 0.92);
+    display: block;
+}
+.page4-q2-other-input-bg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    max-width: none;
+    pointer-events: none;
+}
+.page4-q2-other-input-field {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 81.25%;
+    height: 50%;
+    background: transparent;
     border: none;
-    border-radius: 999px;
     color: #ffffff;
     caret-color: #ffffff;
     font-size: clamp(16px, 3.5vw, 18px);
     font-family: inherit;
     font-weight: 500;
-    padding: 0 5.5%;
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
+    padding: 0 4.375%;
+    text-align: left;
 }
-.page4-q2-other-input::placeholder {
-    color: rgba(255, 255, 255, 0.7);
+.page4-q2-other-input-field::placeholder {
+    color: rgba(255, 255, 255, 0.68);
 }
-.page4-q2-other-input:focus-visible {
+.page4-q2-other-input-field:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.9);
     border-radius: 999px;

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,8 @@ const AGE_TEXT_SOURCES = ["/age_text_image.png", "/age_text_image.png"];
 const GENDER_TEXT_SOURCES = ["/gender_text_image.png", "/gender_text_image.png"];
 const SCROLL_LINE_SOURCES = ["/scroll_line_image.png", "/scroll_line.png"];
 const SCROLL_HANDLE_SOURCES = ["/scroll_handle_image.png", "/scroll_handle.png"];
+const PHONE_STAGE_DESIGN_WIDTH = 375;
+const PHONE_STAGE_DESIGN_HEIGHT = 812;
 const AGE_TRACK_LEFT_PERCENT = 7.466667;
 const AGE_TRACK_WIDTH_PERCENT = 90.4;
 const AGE_TRACK_START_OFFSET_PERCENT = (25 / 339) * AGE_TRACK_WIDTH_PERCENT;
@@ -155,7 +157,7 @@ const Q2_OPTIONS = [
         allowsCustomInput: true,
     },
 ];
-const Q2_STAGE_HEIGHT = 812;
+const Q2_STAGE_HEIGHT = PHONE_STAGE_DESIGN_HEIGHT;
 const Q2_OPTION_WIDTH = 323; // option width in the 375px design
 const Q2_TOGGLE_IMAGE_SIZE = 24;
 const Q2_LABEL_LEFT_PERCENT = (46 / Q2_OPTION_WIDTH) * 100;
@@ -215,7 +217,7 @@ const Q3_OPTIONS = [
         labelHeight: 73,
     },
 ];
-const Q3_STAGE_HEIGHT = 812;
+const Q3_STAGE_HEIGHT = PHONE_STAGE_DESIGN_HEIGHT;
 const Q3_TOGGLE_IMAGE_SIZE = Q2_TOGGLE_IMAGE_SIZE;
 const Q3_LABEL_LEFT_PERCENT = Q2_LABEL_LEFT_PERCENT;
 const Q3_LABEL_WIDTH_PERCENT = Q2_LABEL_WIDTH_PERCENT;
@@ -350,6 +352,8 @@ const Q5_OPTIONS_CONTAINER_HEIGHT = Q5_OPTIONS.reduce((maxBottom, option) => {
     return bottom > maxBottom ? bottom : maxBottom;
 }, 0);
 const ENDING_IMAGE_SOURCES = ["/ending.png"];
+const VIEWPORT_HEIGHT_EPSILON = 1;
+const KEYBOARD_VISUAL_VIEWPORT_GAP = 120;
 
 function ImgWithFallback({ sources = [], alt, ...imgProps }) {
     const [activeIndex, setActiveIndex] = useState(0);
@@ -402,6 +406,7 @@ export default function App() {
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState(null);
     const genderOptionCount = GENDER_OPTIONS.length;
+    const phoneStageRef = useRef(null);
     const genderOptionRefs = useRef([]);
     const q1OptionCount = Q1_OPTIONS.length;
     const q1OptionRefs = useRef([]);
@@ -413,6 +418,7 @@ export default function App() {
     const q4OptionRefs = useRef([]);
     const q5OptionCount = Q5_OPTIONS.length;
     const q5OptionRefs = useRef([]);
+    const wasKeyboardOpenRef = useRef(false);
     const q2OtherInputRef = useRef(null);
     const initialEmailRef = useRef("");
     const focusGenderOption = useCallback(
@@ -694,6 +700,141 @@ export default function App() {
         setAgeInteracted(true);
     }, []);
     useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const rootElement = document.documentElement;
+        if (!rootElement) {
+            return;
+        }
+
+        const updateViewportHeight = () => {
+            const { innerHeight, innerWidth, visualViewport } = window;
+            const { clientHeight, clientWidth } = rootElement;
+
+            const candidateWidths = [];
+
+            if (innerWidth > 0 && Number.isFinite(innerWidth)) {
+                candidateWidths.push(innerWidth);
+            }
+
+            if (clientWidth > 0 && Number.isFinite(clientWidth)) {
+                candidateWidths.push(clientWidth);
+            }
+
+            if (visualViewport) {
+                const { width } = visualViewport;
+                if (width > 0 && Number.isFinite(width)) {
+                    candidateWidths.push(width);
+                }
+            }
+
+            if (candidateWidths.length > 0) {
+                const layoutViewportWidth = Math.max(...candidateWidths);
+                const phoneStageWidth = layoutViewportWidth;
+                const phoneStageHeight =
+                    (phoneStageWidth / PHONE_STAGE_DESIGN_WIDTH) *
+                    PHONE_STAGE_DESIGN_HEIGHT;
+
+                rootElement.style.setProperty(
+                    "--phone-stage-width",
+                    `${phoneStageWidth}px`
+                );
+                rootElement.style.setProperty(
+                    "--phone-stage-height",
+                    `${phoneStageHeight}px`
+                );
+            }
+
+            const candidateHeights = [];
+
+            if (innerHeight > 0 && Number.isFinite(innerHeight)) {
+                candidateHeights.push(innerHeight);
+            }
+
+            if (clientHeight > 0 && Number.isFinite(clientHeight)) {
+                candidateHeights.push(clientHeight);
+            }
+
+            if (candidateHeights.length === 0) {
+                return;
+            }
+
+            const layoutViewportHeight = Math.max(...candidateHeights);
+
+            let visualViewportHeight = null;
+            if (visualViewport) {
+                const { height } = visualViewport;
+                if (height > 0 && Number.isFinite(height)) {
+                    visualViewportHeight = height;
+                }
+
+                if (
+                    visualViewportHeight !== null &&
+                    layoutViewportHeight - visualViewportHeight >
+                        KEYBOARD_VISUAL_VIEWPORT_GAP
+                ) {
+                    wasKeyboardOpenRef.current = true;
+                    return;
+                }
+            }
+
+            const nextViewportHeight = Math.max(
+                layoutViewportHeight,
+                visualViewportHeight ?? 0
+            );
+
+            rootElement.style.setProperty(
+                "--app-viewport-height",
+                `${nextViewportHeight}px`
+            );
+
+            if (wasKeyboardOpenRef.current) {
+                if (Math.abs(window.scrollY) > VIEWPORT_HEIGHT_EPSILON) {
+                    window.scrollTo(0, 0);
+                }
+
+                const phoneStage = phoneStageRef.current;
+                if (
+                    phoneStage &&
+                    Math.abs(phoneStage.scrollTop) > VIEWPORT_HEIGHT_EPSILON
+                ) {
+                    phoneStage.scrollTop = 0;
+                }
+            }
+
+            wasKeyboardOpenRef.current = false;
+        };
+
+        updateViewportHeight();
+
+        window.addEventListener("resize", updateViewportHeight);
+        window.addEventListener("orientationchange", updateViewportHeight);
+
+        const visualViewport = window.visualViewport;
+        if (visualViewport) {
+            visualViewport.addEventListener("resize", updateViewportHeight);
+            visualViewport.addEventListener("scroll", updateViewportHeight);
+        }
+
+        return () => {
+            window.removeEventListener("resize", updateViewportHeight);
+            window.removeEventListener("orientationchange", updateViewportHeight);
+
+            if (visualViewport) {
+                visualViewport.removeEventListener(
+                    "resize",
+                    updateViewportHeight
+                );
+                visualViewport.removeEventListener(
+                    "scroll",
+                    updateViewportHeight
+                );
+            }
+        };
+    }, []);
+    useEffect(() => {
         genderOptionRefs.current = genderOptionRefs.current.slice(0, genderOptionCount);
     }, [genderOptionCount]);
     useEffect(() => {
@@ -711,6 +852,42 @@ export default function App() {
     useEffect(() => {
         q5OptionRefs.current = q5OptionRefs.current.slice(0, q5OptionCount);
     }, [q5OptionCount]);
+    useEffect(() => {
+        const phoneStage = phoneStageRef.current;
+        if (phoneStage) {
+            phoneStage.scrollTop = 0;
+        }
+    }, [page]);
+    useEffect(() => {
+        if (page !== 0 || expanded) {
+            return;
+        }
+
+        const phoneStage = phoneStageRef.current;
+        if (!phoneStage) {
+            return;
+        }
+
+        const ensureExpanded = () => {
+            setExpanded((previous) => (previous ? previous : true));
+        };
+
+        const handleScroll = () => {
+            if (phoneStage.scrollTop > 0) {
+                ensureExpanded();
+            }
+        };
+
+        phoneStage.addEventListener("scroll", handleScroll);
+        phoneStage.addEventListener("wheel", ensureExpanded, { passive: true });
+        phoneStage.addEventListener("touchmove", ensureExpanded, { passive: true });
+
+        return () => {
+            phoneStage.removeEventListener("scroll", handleScroll);
+            phoneStage.removeEventListener("wheel", ensureExpanded);
+            phoneStage.removeEventListener("touchmove", ensureExpanded);
+        };
+    }, [expanded, page]);
     useEffect(() => {
         if (page !== 7) {
             setSubmitError(null);
@@ -855,100 +1032,109 @@ export default function App() {
     }, [bg0, bg1, bg2, bg3, bg4, page]);
     const page0StateClass = expanded ? "is-expanded" : "is-collapsed";
 
-    // ----- PAGE 1 (임시) -----
-    if (page === 1) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page1">
-                        <ImgWithFallback
-                            className="page1-basic-info"
-                            sources={BASIC_INFO_SOURCES}
-                            alt="기본 정보"
-                        />
-                        <ImgWithFallback
-                            className="page1-email-image"
-                            sources={EMAIL_IMAGE_SOURCES}
-                            alt="이메일 안내"
-                        />
-                        <label className="page1-email-input">
-                            <span className="sr-only">이메일 주소 입력</span>
-                            <ImgWithFallback
-                                className="page1-email-input-bg"
-                                sources={EMAIL_TEXT_BOX_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                            <input
-                                type="email"
-                                value={email}
-                                onChange={(event) => setEmail(event.target.value)}
-                                placeholder="이메일을 입력하세요"
-                                autoComplete="email"
-                            />
-                        </label>
-                        <button
-                            className="img-btn page1-before-btn"
-                            type="button"
-                            onClick={() => setPage(0)}
-                            aria-label="이전 페이지"
-                            title="이전 페이지로 돌아가기"
+    const renderPhoneStage = useCallback(
+        (content, { innerClassName } = {}) => {
+            const innerClasses = ["phone-stage-inner"];
+            if (innerClassName) {
+                innerClasses.push(innerClassName);
+            }
+
+            return (
+                <div className="app-root">
+                    <div className="phone-stage" ref={phoneStageRef}>
+                        <div
+                            className={innerClasses.join(" ")}
+                            style={{
+                                backgroundImage: `url(${bgUrl})`,
+                            }}
                         >
-                            <ImgWithFallback
-                                className="page1-before-btn-img"
-                                sources={BEFORE_BUTTON_SOURCES}
-                                alt="이전"
-                            />
-                        </button>
-                        <button
-                            className="img-btn page1-next-btn"
-                            type="button"
-                            onClick={handleAdvanceFromPage1}
-                            aria-label="다음 페이지"
-                            title={
-                                canAdvanceFromPage1
-                                    ? "다음 페이지로 이동"
-                                    : "이메일을 입력하면 다음 페이지로 이동할 수 있습니다"
-                            }
-                            disabled={!canAdvanceFromPage1}
-                        >
-                            <ImgWithFallback
-                                className="page1-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage1
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page1-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
+                            {content}
+                        </div>
                     </div>
                 </div>
+            );
+        },
+        [bgUrl]
+    );
+
+    // ----- PAGE 1 (임시) -----
+    if (page === 1) {
+        return renderPhoneStage(
+            <div className="page page1">
+                <ImgWithFallback
+                    className="page1-basic-info"
+                    sources={BASIC_INFO_SOURCES}
+                    alt="기본 정보"
+                />
+                <ImgWithFallback
+                    className="page1-email-image"
+                    sources={EMAIL_IMAGE_SOURCES}
+                    alt="이메일 안내"
+                />
+                <label className="page1-email-input">
+                    <span className="sr-only">이메일 주소 입력</span>
+                    <ImgWithFallback
+                        className="page1-email-input-bg"
+                        sources={EMAIL_TEXT_BOX_SOURCES}
+                        alt=""
+                        aria-hidden="true"
+                    />
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(event) => setEmail(event.target.value)}
+                        placeholder="이메일을 입력하세요"
+                        autoComplete="email"
+                    />
+                </label>
+                <button
+                    className="img-btn page1-before-btn"
+                    type="button"
+                    onClick={() => setPage(0)}
+                    aria-label="이전 페이지"
+                    title="이전 페이지로 돌아가기"
+                >
+                    <ImgWithFallback
+                        className="page1-before-btn-img"
+                        sources={BEFORE_BUTTON_SOURCES}
+                        alt="이전"
+                    />
+                </button>
+                <button
+                    className="img-btn page1-next-btn"
+                    type="button"
+                    onClick={handleAdvanceFromPage1}
+                    aria-label="다음 페이지"
+                    title={
+                        canAdvanceFromPage1
+                            ? "다음 페이지로 이동"
+                            : "이메일을 입력하면 다음 페이지로 이동할 수 있습니다"
+                    }
+                    disabled={!canAdvanceFromPage1}
+                >
+                    <ImgWithFallback
+                        className="page1-next-btn-img"
+                        sources={
+                            canAdvanceFromPage1
+                                ? NEXT_ON_BUTTON_SOURCES
+                                : NEXT_OFF_BUTTON_SOURCES
+                        }
+                        alt="다음"
+                    />
+                    <ImgWithFallback
+                        className="page1-next-text"
+                        sources={NEXT_TEXT_SOURCES}
+                        alt=""
+                        aria-hidden="true"
+                    />
+                </button>
             </div>
         );
     }
 
     if (page === 2) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page2">
+        return renderPhoneStage(
+            <div className="page page2">
                         <ImgWithFallback
                             className="page2-basic-info"
                             sources={BASIC_INFO_SOURCES}
@@ -1091,22 +1277,13 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 3) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page3">
+        return renderPhoneStage(
+            <div className="page page3">
                         <ImgWithFallback
                             className="page3-q1-title"
                             sources={Q1_TITLE_SOURCES}
@@ -1217,22 +1394,13 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 4) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page4">
+        return renderPhoneStage(
+            <div className="page page4">
                         <ImgWithFallback
                             className="page4-q2-title"
                             sources={Q2_TITLE_SOURCES}
@@ -1321,23 +1489,37 @@ export default function App() {
                                             />
                                         </button>
                                         {option.allowsCustomInput && isSelected ? (
-                                            <input
-                                                ref={q2OtherInputRef}
+                                            <label
                                                 className="page4-q2-other-input"
-                                                type="text"
-                                                value={q2OtherText}
-                                                onChange={(event) =>
-                                                    setQ2OtherText(event.target.value)
-                                                }
-                                                placeholder="직접 입력"
-                                                aria-label="기타 의견 입력"
                                                 style={{
                                                     top: `${labelTopPercent}%`,
                                                     height: `${labelHeightPercent}%`,
                                                     left: `${Q2_LABEL_LEFT_PERCENT}%`,
                                                     width: `${Q2_LABEL_WIDTH_PERCENT}%`,
                                                 }}
-                                            />
+                                            >
+                                                <span className="sr-only">
+                                                    기타 의견 입력
+                                                </span>
+                                                <ImgWithFallback
+                                                    className="page4-q2-other-input-bg"
+                                                    sources={EMAIL_TEXT_BOX_SOURCES}
+                                                    alt=""
+                                                    aria-hidden="true"
+                                                />
+                                                <input
+                                                    ref={q2OtherInputRef}
+                                                    className="page4-q2-other-input-field"
+                                                    type="text"
+                                                    value={q2OtherText}
+                                                    onChange={(event) =>
+                                                        setQ2OtherText(
+                                                            event.target.value
+                                                        )
+                                                    }
+                                                    placeholder="직접 입력"
+                                                />
+                                            </label>
                                         ) : null}
                                     </div>
                                 );
@@ -1393,22 +1575,13 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 5) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page5">
+        return renderPhoneStage(
+            <div className="page page5">
                         <ImgWithFallback
                             className="page5-q3-title"
                             sources={Q3_TITLE_SOURCES}
@@ -1568,22 +1741,13 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 6) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page6">
+        return renderPhoneStage(
+            <div className="page page6">
                         <ImgWithFallback
                             className="page6-q4-title"
                             sources={Q4_TITLE_SOURCES}
@@ -1700,22 +1864,13 @@ export default function App() {
                                 aria-hidden="true"
                             />
                         </button>
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 7) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page7">
+        return renderPhoneStage(
+            <div className="page page7">
                         <ImgWithFallback
                             className="page7-q5-title"
                             sources={Q5_TITLE_SOURCES}
@@ -1849,43 +2004,25 @@ export default function App() {
                                 설문을 저장하는 중입니다.
                             </div>
                         ) : null}
-                    </div>
-                </div>
             </div>
         );
     }
 
     if (page === 8) {
-        return (
-            <div className="app-root">
-                <div
-                    className="phone-stage"
-                    style={{
-                        backgroundImage: `url(${bgUrl})`,
-                    }}
-                >
-                    <div className="page page8">
+        return renderPhoneStage(
+            <div className="page page8">
                         <ImgWithFallback
                             className="page8-ending-image"
                             sources={ENDING_IMAGE_SOURCES}
                             alt="설문이 완료되었습니다"
                         />
-                    </div>
-                </div>
             </div>
         );
     }
 
     // ----- PAGE 0 -----
-    return (
-        <div className="app-root">
-            <div
-                className="phone-stage"
-                style={{
-                    backgroundImage: `url(${bgUrl})`,
-                }}
-            >
-                <div className={`page page0 ${page0StateClass}`}>
+    return renderPhoneStage(
+        <div className={`page page0 ${page0StateClass}`}>
                     {/* 1) EntryText 이미지 */}
                     <img
                         className="page0-entry-img page0-entry-img-top"
@@ -1947,8 +2084,6 @@ export default function App() {
                             <img src="/start_off_button.png" alt="START 비활성" />
                         </button>
                     )}
-                </div>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- reposition the entry text, start, agree, and arrow controls to match the updated asset layout
- adjust the collapsed and expanded entry text positions to align with the new design
- auto-expand the landing text when the user scrolls or drags within the phone stage

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3cc3de00c83229f6c7fb6cf2b20fe