### PR TITLE
Add sliding transitions and preload survey images

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,29 @@
     display: flex;
     flex-direction: column;
     position: relative;
+    will-change: transform;
+}
+
+.phone-stage-inner.phone-stage-slide-in {
+    animation: phone-stage-slide-in-from-right 450ms ease both;
+}
+
+@keyframes phone-stage-slide-in-from-right {
+    from {
+        transform: translateX(20%);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .phone-stage-inner.phone-stage-slide-in {
+        animation: none;
+    }
 }
 
 /* 실제 페이지 콘텐츠는 phone-stage 안에서 배치 */


### PR DESCRIPTION
## Summary
- preload all survey assets so screen changes reuse cached images
- add a slide-in-from-right animation during page transitions for a smoother experience
- align the "complicated production process" artwork to the requested coordinates and dimensions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4db448f288322a34fcbff12fb1572