### PR TITLE
Make next and done buttons stick to viewport edges

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -314,11 +314,11 @@
 
 .page-bottom-nav {
     position: fixed;
-    left: 50%;
+    left: 0;
+    right: 0;
     bottom: 0;
-    width: min(var(--phone-stage-width), 100vw);
+    width: 100vw;
     height: var(--page-nav-height);
-    transform: translateX(-50%);
     display: flex;
     z-index: 100;
 }


### PR DESCRIPTION
## Summary
- pin the bottom navigation bar to span the full viewport width so the Next and Done buttons touch both edges regardless of scroll

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f421eca88322baa6864c42090420