### PR TITLE
Update survey layout and support typed Other responses

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,58 +111,52 @@
     padding: 0;
 }
 
+
 .page0-entry-img {
     position: absolute;
-    left: 5.0667%;
-    width: 89.6%;
     max-width: none;
     height: auto;
-    transition: top 600ms ease;
+    opacity: 0;
+    transform: translateY(8%);
+    transition: opacity 600ms ease, transform 600ms ease;
+    pointer-events: none;
+}
+
+.page0-entry-img-top {
+    left: 5.8667%;
+    top: 66.625%;
+    width: 89.6%;
 }
 
 .page0-entry-img-bottom {
-    left: 3.2%;
-    width: 99.7333%;
+    left: 4%;
+    top: 77.9635%;
+    width: 93.3333%;
 }
 
-.page0.is-collapsed .page0-entry-img-top {
-    top: 73.7685%;
-}
-
-.page0.is-expanded .page0-entry-img-top {
-    top: 64.6552%;
-}
-
-.page0.is-collapsed .page0-entry-img-bottom {
-    top: 84.9754%;
-}
-
-.page0.is-expanded .page0-entry-img-bottom {
-    top: 75.9852%;
+.page0.is-expanded .page0-entry-img {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .page0-entry-fade {
     position: absolute;
-    left: 3.2%;
+    left: 4%;
+    top: 77.9635%;
     width: 93.3333%;
-    height: 9.4828%;
+    height: 10.591133%;
     background: linear-gradient(
         to bottom,
         rgba(0, 0, 0, 0),
         rgba(0, 0, 0, 0.85)
     );
-    opacity: 1;
-    transition: top 600ms ease, opacity 600ms ease;
+    opacity: 0;
+    transition: opacity 600ms ease;
     pointer-events: none;
 }
 
-.page0.is-collapsed .page0-entry-fade {
-    top: 84.9754%;
-}
-
 .page0.is-expanded .page0-entry-fade {
-    top: 75.9852%;
-    opacity: 0;
+    opacity: 1;
 }
 
 .page0 .arrow-button,
@@ -172,8 +166,8 @@
 }
 
 .page0 .arrow-button {
-    left: 47.7333%;
-    top: 88.0542%;
+    left: 47.4667%;
+    top: 63.5463%;
     width: 4%;
     transition: opacity 220ms ease;
 }
@@ -184,14 +178,14 @@
 }
 
 .page0 .agree-btn {
-    left: 36.5333%;
-    top: 90.1478%;
+    left: 36.2667%;
+    top: 59.3603%;
     width: 26.6667%;
 }
 
 .page0 .start-btn {
     left: 28%;
-    top: 48.2759%;
+    top: 50.1232%;
     width: 44%;
 }
 
@@ -314,11 +308,10 @@
 
 .page-bottom-nav {
     position: fixed;
-    left: 50%;
+    left: 0;
+    right: 0;
     bottom: 0;
-    width: min(var(--phone-stage-width), 100vw);
     height: var(--page-nav-height);
-    transform: translateX(-50%);
     display: flex;
     z-index: 100;
 }
@@ -618,11 +611,16 @@
     width: 100%;
     height: 100%;
 }
-.page3-q1-option {
+.page3-q1-option-wrapper {
     position: absolute;
     left: 6.133333%;
     width: 86.133333%;
     height: 10.098522%;
+}
+.page3-q1-option-button {
+    position: relative;
+    width: 100%;
+    height: 100%;
     background: none;
     border: none;
     padding: 0;
@@ -630,11 +628,11 @@
     display: block;
     cursor: pointer;
 }
-.page3-q1-option:focus-visible {
+.page3-q1-option-button:focus-visible {
     outline: 2px solid #fff;
     outline-offset: 2px;
 }
-.page3-q1-option:disabled {
+.page3-q1-option-button:disabled {
     cursor: default;
 }
 .page3-q1-toggle {
@@ -656,6 +654,12 @@
     max-width: none;
     display: block;
     pointer-events: none;
+}
+.page3-q1-other-input {
+    left: 14.241486%;
+    top: 0;
+    width: 85.758514%;
+    height: 73.170732%;
 }
 .page3-before-btn {
     position: absolute;
@@ -740,11 +744,13 @@
     display: block;
     pointer-events: none;
 }
+.option-other-input,
 .page4-q2-other-input {
     position: absolute;
     z-index: 2;
     display: block;
 }
+.option-other-input-bg,
 .page4-q2-other-input-bg {
     width: 100%;
     height: 100%;
@@ -752,6 +758,7 @@
     max-width: none;
     pointer-events: none;
 }
+.option-other-input-field,
 .page4-q2-other-input-field {
     position: absolute;
     top: 50%;
@@ -769,9 +776,11 @@
     padding: 0 4.375%;
     text-align: left;
 }
+.option-other-input-field::placeholder,
 .page4-q2-other-input-field::placeholder {
     color: rgba(255, 255, 255, 0.68);
 }
+.option-other-input-field:focus-visible,
 .page4-q2-other-input-field:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.9);
@@ -899,15 +908,15 @@
 .page6-q4-options {
     position: absolute;
     left: 6.133333%;
-    top: 32.512315%;
+    top: 26.973891%;
     width: 86.133333%;
-    height: 46.305419%;
+    height: 50.492611%;
 }
 .page6-q4-option {
     position: absolute;
     left: 0;
     width: 100%;
-    height: 15.957447%;
+    height: 20%;
 }
 .page6-q4-option-button {
     position: relative;
@@ -946,6 +955,12 @@
     max-width: none;
     display: block;
     pointer-events: none;
+}
+.page6-q4-other-input {
+    left: 14.241486%;
+    top: 0;
+    width: 85.758514%;
+    height: 100%;
 }
 .page6-before-btn {
     position: absolute;
@@ -1043,6 +1058,12 @@
     max-width: none;
     display: block;
     pointer-events: none;
+}
+.page7-q5-other-input {
+    left: 14.241486%;
+    top: 0;
+    width: 85.758514%;
+    height: 100%;
 }
 
 .page7-before-btn {

--- a/src/App.js
+++ b/src/App.js
@@ -53,7 +53,6 @@ import {
     Q3_OPTIONS_CONTAINER_STAGE_HEIGHT,
     Q3_OPTIONS_CONTAINER_STAGE_TOP,
     Q3_OPTIONS_CONTAINER_TOP_PERCENT,
-    Q3_STAGE_HEIGHT,
     Q3_TEXT_SOURCES,
     Q3_TITLE_SOURCES,
     Q3_TOGGLE_IMAGE_SIZE,
@@ -82,11 +81,15 @@ export default function App() {
     const [ageInteracted, setAgeInteracted] = useState(false);
     const [gender, setGender] = useState(null);
     const [q1Answer, setQ1Answer] = useState(null);
+    const [q1OtherText, setQ1OtherText] = useState("");
     const [q2Answer, setQ2Answer] = useState(null);
     const [q2OtherText, setQ2OtherText] = useState("");
     const [q3Answer, setQ3Answer] = useState(null);
+    const [q3OtherText, setQ3OtherText] = useState("");
     const [q4Answer, setQ4Answer] = useState(null);
+    const [q4OtherText, setQ4OtherText] = useState("");
     const [q5Answer, setQ5Answer] = useState(null);
+    const [q5OtherText, setQ5OtherText] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState(null);
     const [transitionClass, setTransitionClass] = useState("");
@@ -105,7 +108,11 @@ export default function App() {
     const q5OptionRefs = useRef([]);
     const hasMountedTransitionRef = useRef(false);
     const wasKeyboardOpenRef = useRef(false);
+    const q1OtherInputRef = useRef(null);
     const q2OtherInputRef = useRef(null);
+    const q3OtherInputRef = useRef(null);
+    const q4OtherInputRef = useRef(null);
+    const q5OtherInputRef = useRef(null);
     const initialEmailRef = useRef("");
     const [phoneStageElement, setPhoneStageElement] = useState(null);
     const [questionLayoutScale, setQuestionLayoutScale] = useState(1);
@@ -197,6 +204,25 @@ export default function App() {
         },
         [focusGenderOption, genderOptionCount]
     );
+    const handleSelectQ1Option = useCallback(
+        (optionId, focusInput = false) => {
+            setQ1Answer(optionId);
+            if (optionId === "other") {
+                if (focusInput) {
+                    setTimeout(() => {
+                        const input = q1OtherInputRef.current;
+                        if (input) {
+                            input.focus();
+                            input.select();
+                        }
+                    }, 0);
+                }
+            } else {
+                setQ1OtherText("");
+            }
+        },
+        []
+    );
     const handleQ1KeyDown = useCallback(
         (event, optionIndex) => {
             if (q1OptionCount <= 0) {
@@ -206,26 +232,26 @@ export default function App() {
             if (event.key === "ArrowRight" || event.key === "ArrowDown") {
                 event.preventDefault();
                 const nextIndex = (optionIndex + 1) % q1OptionCount;
-                setQ1Answer(Q1_OPTIONS[nextIndex].id);
+                handleSelectQ1Option(Q1_OPTIONS[nextIndex].id);
                 focusQ1Option(nextIndex);
             } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
                 event.preventDefault();
                 const previousIndex =
                     (optionIndex - 1 + q1OptionCount) % q1OptionCount;
-                setQ1Answer(Q1_OPTIONS[previousIndex].id);
+                handleSelectQ1Option(Q1_OPTIONS[previousIndex].id);
                 focusQ1Option(previousIndex);
             } else if (event.key === "Home") {
                 event.preventDefault();
-                setQ1Answer(Q1_OPTIONS[0].id);
+                handleSelectQ1Option(Q1_OPTIONS[0].id);
                 focusQ1Option(0);
             } else if (event.key === "End") {
                 event.preventDefault();
                 const lastIndex = q1OptionCount - 1;
-                setQ1Answer(Q1_OPTIONS[lastIndex].id);
+                handleSelectQ1Option(Q1_OPTIONS[lastIndex].id);
                 focusQ1Option(lastIndex);
             }
         },
-        [focusQ1Option, q1OptionCount]
+        [focusQ1Option, handleSelectQ1Option, q1OptionCount]
     );
     const handleSelectQ2Option = useCallback((optionId, focusInput = false) => {
         setQ2Answer(optionId);
@@ -273,6 +299,25 @@ export default function App() {
         },
         [focusQ2Option, handleSelectQ2Option, q2OptionCount]
     );
+    const handleSelectQ3Option = useCallback(
+        (optionId, focusInput = false) => {
+            setQ3Answer(optionId);
+            if (optionId === "other") {
+                if (focusInput) {
+                    setTimeout(() => {
+                        const input = q3OtherInputRef.current;
+                        if (input) {
+                            input.focus();
+                            input.select();
+                        }
+                    }, 0);
+                }
+            } else {
+                setQ3OtherText("");
+            }
+        },
+        []
+    );
     const handleQ3KeyDown = useCallback(
         (event, optionIndex) => {
             if (q3OptionCount <= 0) {
@@ -282,26 +327,45 @@ export default function App() {
             if (event.key === "ArrowRight" || event.key === "ArrowDown") {
                 event.preventDefault();
                 const nextIndex = (optionIndex + 1) % q3OptionCount;
-                setQ3Answer(Q3_OPTIONS[nextIndex].id);
+                handleSelectQ3Option(Q3_OPTIONS[nextIndex].id);
                 focusQ3Option(nextIndex);
             } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
                 event.preventDefault();
                 const previousIndex =
                     (optionIndex - 1 + q3OptionCount) % q3OptionCount;
-                setQ3Answer(Q3_OPTIONS[previousIndex].id);
+                handleSelectQ3Option(Q3_OPTIONS[previousIndex].id);
                 focusQ3Option(previousIndex);
             } else if (event.key === "Home") {
                 event.preventDefault();
-                setQ3Answer(Q3_OPTIONS[0].id);
+                handleSelectQ3Option(Q3_OPTIONS[0].id);
                 focusQ3Option(0);
             } else if (event.key === "End") {
                 event.preventDefault();
                 const lastIndex = q3OptionCount - 1;
-                setQ3Answer(Q3_OPTIONS[lastIndex].id);
+                handleSelectQ3Option(Q3_OPTIONS[lastIndex].id);
                 focusQ3Option(lastIndex);
             }
         },
-        [focusQ3Option, q3OptionCount]
+        [focusQ3Option, handleSelectQ3Option, q3OptionCount]
+    );
+    const handleSelectQ4Option = useCallback(
+        (optionId, focusInput = false) => {
+            setQ4Answer(optionId);
+            if (optionId === "other") {
+                if (focusInput) {
+                    setTimeout(() => {
+                        const input = q4OtherInputRef.current;
+                        if (input) {
+                            input.focus();
+                            input.select();
+                        }
+                    }, 0);
+                }
+            } else {
+                setQ4OtherText("");
+            }
+        },
+        []
     );
     const handleQ4KeyDown = useCallback(
         (event, optionIndex) => {
@@ -312,26 +376,45 @@ export default function App() {
             if (event.key === "ArrowRight" || event.key === "ArrowDown") {
                 event.preventDefault();
                 const nextIndex = (optionIndex + 1) % q4OptionCount;
-                setQ4Answer(Q4_OPTIONS[nextIndex].id);
+                handleSelectQ4Option(Q4_OPTIONS[nextIndex].id);
                 focusQ4Option(nextIndex);
             } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
                 event.preventDefault();
                 const previousIndex =
                     (optionIndex - 1 + q4OptionCount) % q4OptionCount;
-                setQ4Answer(Q4_OPTIONS[previousIndex].id);
+                handleSelectQ4Option(Q4_OPTIONS[previousIndex].id);
                 focusQ4Option(previousIndex);
             } else if (event.key === "Home") {
                 event.preventDefault();
-                setQ4Answer(Q4_OPTIONS[0].id);
+                handleSelectQ4Option(Q4_OPTIONS[0].id);
                 focusQ4Option(0);
             } else if (event.key === "End") {
                 event.preventDefault();
                 const lastIndex = q4OptionCount - 1;
-                setQ4Answer(Q4_OPTIONS[lastIndex].id);
+                handleSelectQ4Option(Q4_OPTIONS[lastIndex].id);
                 focusQ4Option(lastIndex);
             }
         },
-        [focusQ4Option, q4OptionCount]
+        [focusQ4Option, handleSelectQ4Option, q4OptionCount]
+    );
+    const handleSelectQ5Option = useCallback(
+        (optionId, focusInput = false) => {
+            setQ5Answer(optionId);
+            if (optionId === "other") {
+                if (focusInput) {
+                    setTimeout(() => {
+                        const input = q5OtherInputRef.current;
+                        if (input) {
+                            input.focus();
+                            input.select();
+                        }
+                    }, 0);
+                }
+            } else {
+                setQ5OtherText("");
+            }
+        },
+        []
     );
     const handleQ5KeyDown = useCallback(
         (event, optionIndex) => {
@@ -342,26 +425,26 @@ export default function App() {
             if (event.key === "ArrowRight" || event.key === "ArrowDown") {
                 event.preventDefault();
                 const nextIndex = (optionIndex + 1) % q5OptionCount;
-                setQ5Answer(Q5_OPTIONS[nextIndex].id);
+                handleSelectQ5Option(Q5_OPTIONS[nextIndex].id);
                 focusQ5Option(nextIndex);
             } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
                 event.preventDefault();
                 const previousIndex =
                     (optionIndex - 1 + q5OptionCount) % q5OptionCount;
-                setQ5Answer(Q5_OPTIONS[previousIndex].id);
+                handleSelectQ5Option(Q5_OPTIONS[previousIndex].id);
                 focusQ5Option(previousIndex);
             } else if (event.key === "Home") {
                 event.preventDefault();
-                setQ5Answer(Q5_OPTIONS[0].id);
+                handleSelectQ5Option(Q5_OPTIONS[0].id);
                 focusQ5Option(0);
             } else if (event.key === "End") {
                 event.preventDefault();
                 const lastIndex = q5OptionCount - 1;
-                setQ5Answer(Q5_OPTIONS[lastIndex].id);
+                handleSelectQ5Option(Q5_OPTIONS[lastIndex].id);
                 focusQ5Option(lastIndex);
             }
         },
-        [focusQ5Option, q5OptionCount]
+        [focusQ5Option, handleSelectQ5Option, q5OptionCount]
     );
     const ageStopCount = AGE_STOPS.length;
     const canAdvanceFromPage1 = email.trim().length > 0;
@@ -691,8 +774,16 @@ export default function App() {
         setSubmitting(true);
         setSubmitError(null);
 
-        const trimmedOtherText =
+        const trimmedQ1OtherText =
+            q1Answer === "other" ? q1OtherText.trim() : "";
+        const trimmedQ2OtherText =
             q2Answer === "other" ? q2OtherText.trim() : "";
+        const trimmedQ3OtherText =
+            q3Answer === "other" ? q3OtherText.trim() : "";
+        const trimmedQ4OtherText =
+            q4Answer === "other" ? q4OtherText.trim() : "";
+        const trimmedQ5OtherText =
+            q5Answer === "other" ? q5OtherText.trim() : "";
 
         const payload = {
             email: capturedEmail,
@@ -706,14 +797,30 @@ export default function App() {
                 ageLabel: selectedAgeStop ? selectedAgeStop.label : null,
                 gender,
                 q1: q1Answer,
+                q1OtherText:
+                    q1Answer === "other" && trimmedQ1OtherText.length > 0
+                        ? trimmedQ1OtherText
+                        : null,
                 q2: q2Answer,
                 q2OtherText:
-                    q2Answer === "other" && trimmedOtherText.length > 0
-                        ? trimmedOtherText
+                    q2Answer === "other" && trimmedQ2OtherText.length > 0
+                        ? trimmedQ2OtherText
                         : null,
                 q3: q3Answer,
+                q3OtherText:
+                    q3Answer === "other" && trimmedQ3OtherText.length > 0
+                        ? trimmedQ3OtherText
+                        : null,
                 q4: q4Answer,
+                q4OtherText:
+                    q4Answer === "other" && trimmedQ4OtherText.length > 0
+                        ? trimmedQ4OtherText
+                        : null,
                 q5: q5Answer,
+                q5OtherText:
+                    q5Answer === "other" && trimmedQ5OtherText.length > 0
+                        ? trimmedQ5OtherText
+                        : null,
             },
         };
 
@@ -753,11 +860,15 @@ export default function App() {
         email,
         gender,
         q1Answer,
+        q1OtherText,
         q2Answer,
         q2OtherText,
         q3Answer,
+        q3OtherText,
         q4Answer,
+        q4OtherText,
         q5Answer,
+        q5OtherText,
         selectedAgeStop,
         submitting,
     ]);
@@ -837,7 +948,7 @@ export default function App() {
     const page0StateClass = expanded ? "is-expanded" : "is-collapsed";
 
     const renderPhoneStage = useCallback(
-        (content, { innerClassName } = {}) => {
+        (content, navSection = null, { innerClassName } = {}) => {
             const innerClasses = ["phone-stage-inner"];
             if (innerClassName) {
                 innerClasses.push(innerClassName);
@@ -858,38 +969,40 @@ export default function App() {
                             {content}
                         </div>
                     </div>
+                    {navSection}
                 </div>
             );
         },
-        [bgUrl, transitionClass]
+        [bgUrl, phoneStageRefCallback, transitionClass]
     );
     const renderQuestionLayout = useCallback(
-        (pageClassName, content, navSection = null) => (
-            <div className={`page ${pageClassName}`}>
-                <div className="page-question-area">
-                    <div
-                        className="page-question-scale"
-                        style={{
-                            transform: `scale(${questionLayoutScale})`,
-                            width: `${PHONE_STAGE_DESIGN_WIDTH}px`,
-                            height: `${PHONE_STAGE_DESIGN_HEIGHT}px`,
-                        }}
-                    >
-                        <div className="page-question-inner">{content}</div>
+        (pageClassName, content, navSection = null) => ({
+            page: (
+                <div className={`page ${pageClassName}`}>
+                    <div className="page-question-area">
+                        <div
+                            className="page-question-scale"
+                            style={{
+                                transform: `scale(${questionLayoutScale})`,
+                                width: `${PHONE_STAGE_DESIGN_WIDTH}px`,
+                                height: `${PHONE_STAGE_DESIGN_HEIGHT}px`,
+                            }}
+                        >
+                            <div className="page-question-inner">{content}</div>
+                        </div>
                     </div>
                 </div>
-                {navSection}
-            </div>
-        ),
+            ),
+            nav: navSection,
+        }),
         [questionLayoutScale]
     );
 
     // ----- PAGE 1 (임시) -----
     if (page === 1) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page1",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page1",
+            <>
                     <ImgWithFallback
                         className="page1-basic-info"
                         sources={BASIC_INFO_SOURCES}
@@ -930,47 +1043,46 @@ export default function App() {
                         />
                     </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page1-next-btn"
-                            type="button"
-                            onClick={handleAdvanceFromPage1}
-                            aria-label="다음 페이지"
-                            title={
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page1-next-btn"
+                        type="button"
+                        onClick={handleAdvanceFromPage1}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage1
+                                ? "다음 페이지로 이동"
+                                : "이메일을 입력하면 다음 페이지로 이동할 수 있습니다"
+                        }
+                        disabled={!canAdvanceFromPage1}
+                    >
+                        <ImgWithFallback
+                            className="page1-next-btn-img"
+                            sources={
                                 canAdvanceFromPage1
-                                    ? "다음 페이지로 이동"
-                                    : "이메일을 입력하면 다음 페이지로 이동할 수 있습니다"
+                                    ? NEXT_ON_BUTTON_SOURCES
+                                    : NEXT_OFF_BUTTON_SOURCES
                             }
-                            disabled={!canAdvanceFromPage1}
-                        >
-                            <ImgWithFallback
-                                className="page1-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage1
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page1-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page1-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 2) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page2",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page2",
+            <>
                         <ImgWithFallback
                             className="page2-basic-info"
                             sources={BASIC_INFO_SOURCES}
@@ -1082,51 +1194,50 @@ export default function App() {
                             />
                         </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page2-next-btn"
-                            type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage2) {
-                                    setPage(3);
-                                }
-                            }}
-                            aria-label="다음 페이지"
-                            title={
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page2-next-btn"
+                        type="button"
+                        onClick={() => {
+                            if (canAdvanceFromPage2) {
+                                setPage(3);
+                            }
+                        }}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage2
+                                ? NEXT_ON_BUTTON_SOURCES
+                                : NEXT_OFF_BUTTON_SOURCES
+                        }
+                        disabled={!canAdvanceFromPage2}
+                    >
+                        <ImgWithFallback
+                            className="page2-next-btn-img"
+                            sources={
                                 canAdvanceFromPage2
                                     ? NEXT_ON_BUTTON_SOURCES
                                     : NEXT_OFF_BUTTON_SOURCES
                             }
-                            disabled={!canAdvanceFromPage2}
-                        >
-                            <ImgWithFallback
-                                className="page2-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage2
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page2-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page2-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 3) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page3",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page3",
+            <>
                     <ImgWithFallback
                         className="page3-q1-title"
                         sources={Q1_TITLE_SOURCES}
@@ -1154,36 +1265,74 @@ export default function App() {
                                 Q1_OPTION_STEP_PERCENT * index;
 
                             return (
-                                <button
+                                <div
                                     key={option.id}
-                                    type="button"
-                                    className="page3-q1-option"
+                                    className="page3-q1-option-wrapper"
                                     style={{ top: `${topPercent}%` }}
-                                    onClick={() => setQ1Answer(option.id)}
-                                    onKeyDown={(event) =>
-                                        handleQ1KeyDown(event, index)
-                                    }
-                                    role="radio"
-                                    aria-checked={isSelected}
-                                    tabIndex={isTabStop ? 0 : -1}
-                                    ref={(element) => {
-                                        q1OptionRefs.current[index] = element;
-                                    }}
                                 >
-                                    <span className="sr-only">{option.label}</span>
-                                    <ImgWithFallback
-                                        className="page3-q1-toggle"
-                                        sources={toggleSources}
-                                        alt=""
-                                        aria-hidden="true"
-                                    />
-                                    <ImgWithFallback
-                                        className="page3-q1-label"
-                                        sources={option.imageSources}
-                                        alt=""
-                                        aria-hidden="true"
-                                    />
-                                </button>
+                                    <button
+                                        type="button"
+                                        className="page3-q1-option-button"
+                                        onClick={() =>
+                                            handleSelectQ1Option(
+                                                option.id,
+                                                option.allowsCustomInput ?? false
+                                            )
+                                        }
+                                        onKeyDown={(event) =>
+                                            handleQ1KeyDown(event, index)
+                                        }
+                                        role="radio"
+                                        aria-checked={isSelected}
+                                        tabIndex={isTabStop ? 0 : -1}
+                                        ref={(element) => {
+                                            q1OptionRefs.current[index] = element;
+                                        }}
+                                    >
+                                        <span className="sr-only">{option.label}</span>
+                                        <ImgWithFallback
+                                            className="page3-q1-toggle"
+                                            sources={toggleSources}
+                                            alt=""
+                                            aria-hidden="true"
+                                        />
+                                        <ImgWithFallback
+                                            className="page3-q1-label"
+                                            sources={option.imageSources}
+                                            alt=""
+                                            aria-hidden="true"
+                                        />
+                                    </button>
+                                    {option.allowsCustomInput && isSelected ? (
+                                        <label
+                                            className="option-other-input page3-q1-other-input"
+                                            htmlFor="page3-q1-other"
+                                        >
+                                            <span className="sr-only">
+                                                기타 의견 입력
+                                            </span>
+                                            <ImgWithFallback
+                                                className="option-other-input-bg"
+                                                sources={EMAIL_TEXT_BOX_SOURCES}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <input
+                                                id="page3-q1-other"
+                                                ref={q1OtherInputRef}
+                                                className="option-other-input-field"
+                                                type="text"
+                                                value={q1OtherText}
+                                                onChange={(event) =>
+                                                    setQ1OtherText(
+                                                        event.target.value
+                                                    )
+                                                }
+                                                placeholder="직접 입력"
+                                            />
+                                        </label>
+                                    ) : null}
+                                </div>
                             );
                         })}
                     </div>
@@ -1206,51 +1355,50 @@ export default function App() {
                         />
                     </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page3-next-btn"
-                            type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage3) {
-                                    setPage(4);
-                                }
-                            }}
-                            aria-label="다음 페이지"
-                            title={
-                                canAdvanceFromPage3
-                                    ? "다음 페이지로 이동"
-                                    : "만족도를 선택하면 다음으로 이동할 수 있습니다"
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page3-next-btn"
+                        type="button"
+                        onClick={() => {
+                            if (canAdvanceFromPage3) {
+                                setPage(4);
                             }
-                            disabled={!canAdvanceFromPage3}
-                        >
-                            <ImgWithFallback
-                                className="page3-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage3
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page3-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                        }}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage3
+                                ? "다음 페이지로 이동"
+                                : "만족도를 선택하면 다음으로 이동할 수 있습니다"
+                        }
+                        disabled={!canAdvanceFromPage3}
+                    >
+                        <ImgWithFallback
+                            className="page3-next-btn-img"
+                            sources={
+                                canAdvanceFromPage3
+                                    ? NEXT_ON_BUTTON_SOURCES
+                                    : NEXT_OFF_BUTTON_SOURCES
+                            }
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page3-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 4) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page4",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page4",
+            <>
                     <ImgWithFallback
                         className="page4-q2-title"
                         sources={Q2_TITLE_SOURCES}
@@ -1340,7 +1488,7 @@ export default function App() {
                                     </button>
                                     {option.allowsCustomInput && isSelected ? (
                                         <label
-                                            className="page4-q2-other-input"
+                                            className="option-other-input page4-q2-other-input"
                                             style={{
                                                 top: `${labelTopPercent}%`,
                                                 height: `${labelHeightPercent}%`,
@@ -1352,14 +1500,14 @@ export default function App() {
                                                 기타 의견 입력
                                             </span>
                                             <ImgWithFallback
-                                                className="page4-q2-other-input-bg"
+                                                className="option-other-input-bg"
                                                 sources={EMAIL_TEXT_BOX_SOURCES}
                                                 alt=""
                                                 aria-hidden="true"
                                             />
                                             <input
                                                 ref={q2OtherInputRef}
-                                                className="page4-q2-other-input-field"
+                                                className="option-other-input-field"
                                                 type="text"
                                                 value={q2OtherText}
                                                 onChange={(event) =>
@@ -1394,51 +1542,50 @@ export default function App() {
                         />
                     </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page4-next-btn"
-                            type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage4) {
-                                    setPage(5);
-                                }
-                            }}
-                            aria-label="다음 페이지"
-                            title={
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page4-next-btn"
+                        type="button"
+                        onClick={() => {
+                            if (canAdvanceFromPage4) {
+                                setPage(5);
+                            }
+                        }}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage4
+                                ? NEXT_ON_BUTTON_SOURCES
+                                : NEXT_OFF_BUTTON_SOURCES
+                        }
+                        disabled={!canAdvanceFromPage4}
+                    >
+                        <ImgWithFallback
+                            className="page4-next-btn-img"
+                            sources={
                                 canAdvanceFromPage4
                                     ? NEXT_ON_BUTTON_SOURCES
                                     : NEXT_OFF_BUTTON_SOURCES
                             }
-                            disabled={!canAdvanceFromPage4}
-                        >
-                            <ImgWithFallback
-                                className="page4-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage4
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page4-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page4-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 5) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page5",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page5",
+            <>
                     <ImgWithFallback
                         className="page5-q3-title"
                         sources={Q3_TITLE_SOURCES}
@@ -1508,7 +1655,12 @@ export default function App() {
                                     <button
                                         type="button"
                                         className="page5-q3-option-button"
-                                        onClick={() => setQ3Answer(option.id)}
+                                        onClick={() =>
+                                            handleSelectQ3Option(
+                                                option.id,
+                                                option.allowsCustomInput ?? false
+                                            )
+                                        }
                                         onKeyDown={(event) =>
                                             handleQ3KeyDown(event, index)
                                         }
@@ -1544,6 +1696,39 @@ export default function App() {
                                             }}
                                         />
                                     </button>
+                                    {option.allowsCustomInput && isSelected ? (
+                                        <label
+                                            className="option-other-input page5-q3-other-input"
+                                            style={{
+                                                top: `${labelTopPercent}%`,
+                                                height: `${labelHeightPercent}%`,
+                                                left: `${Q3_LABEL_LEFT_PERCENT}%`,
+                                                width: `${Q3_LABEL_WIDTH_PERCENT}%`,
+                                            }}
+                                        >
+                                            <span className="sr-only">
+                                                기타 의견 입력
+                                            </span>
+                                            <ImgWithFallback
+                                                className="option-other-input-bg"
+                                                sources={EMAIL_TEXT_BOX_SOURCES}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <input
+                                                ref={q3OtherInputRef}
+                                                className="option-other-input-field"
+                                                type="text"
+                                                value={q3OtherText}
+                                                onChange={(event) =>
+                                                    setQ3OtherText(
+                                                        event.target.value
+                                                    )
+                                                }
+                                                placeholder="직접 입력"
+                                            />
+                                        </label>
+                                    ) : null}
                                 </div>
                             );
                         })}
@@ -1567,51 +1752,50 @@ export default function App() {
                         />
                     </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page5-next-btn"
-                            type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage5) {
-                                    setPage(6);
-                                }
-                            }}
-                            aria-label="다음 페이지"
-                            title={
-                                canAdvanceFromPage5
-                                    ? "다음 페이지로 이동"
-                                    : "선택지를 고르면 다음으로 이동할 수 있습니다"
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page5-next-btn"
+                        type="button"
+                        onClick={() => {
+                            if (canAdvanceFromPage5) {
+                                setPage(6);
                             }
-                            disabled={!canAdvanceFromPage5}
-                        >
-                            <ImgWithFallback
-                                className="page5-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage5
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page5-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                        }}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage5
+                                ? "다음 페이지로 이동"
+                                : "선택지를 고르면 다음으로 이동할 수 있습니다"
+                        }
+                        disabled={!canAdvanceFromPage5}
+                    >
+                        <ImgWithFallback
+                            className="page5-next-btn-img"
+                            sources={
+                                canAdvanceFromPage5
+                                    ? NEXT_ON_BUTTON_SOURCES
+                                    : NEXT_OFF_BUTTON_SOURCES
+                            }
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page5-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 6) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page6",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page6",
+            <>
                     <ImgWithFallback
                         className="page6-q4-title"
                         sources={Q4_TITLE_SOURCES}
@@ -1649,7 +1833,12 @@ export default function App() {
                                     <button
                                         type="button"
                                         className="page6-q4-option-button"
-                                        onClick={() => setQ4Answer(option.id)}
+                                        onClick={() =>
+                                            handleSelectQ4Option(
+                                                option.id,
+                                                option.allowsCustomInput ?? false
+                                            )
+                                        }
                                         onKeyDown={(event) =>
                                             handleQ4KeyDown(event, index)
                                         }
@@ -1674,6 +1863,35 @@ export default function App() {
                                             aria-hidden="true"
                                         />
                                     </button>
+                                    {option.allowsCustomInput && isSelected ? (
+                                        <label
+                                            className="option-other-input page6-q4-other-input"
+                                            htmlFor="page6-q4-other"
+                                        >
+                                            <span className="sr-only">
+                                                기타 의견 입력
+                                            </span>
+                                            <ImgWithFallback
+                                                className="option-other-input-bg"
+                                                sources={EMAIL_TEXT_BOX_SOURCES}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <input
+                                                id="page6-q4-other"
+                                                ref={q4OtherInputRef}
+                                                className="option-other-input-field"
+                                                type="text"
+                                                value={q4OtherText}
+                                                onChange={(event) =>
+                                                    setQ4OtherText(
+                                                        event.target.value
+                                                    )
+                                                }
+                                                placeholder="직접 입력"
+                                            />
+                                        </label>
+                                    ) : null}
                                 </div>
                             );
                         })}
@@ -1697,51 +1915,50 @@ export default function App() {
                         />
                     </button>
                 </>,
-                (
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page6-next-btn"
-                            type="button"
-                            onClick={() => {
-                                if (canAdvanceFromPage6) {
-                                    setPage(7);
-                                }
-                            }}
-                            aria-label="다음 페이지"
-                            title={
-                                canAdvanceFromPage6
-                                    ? "다음 페이지로 이동"
-                                    : "선택지를 고르면 다음으로 이동할 수 있습니다"
+            (
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page6-next-btn"
+                        type="button"
+                        onClick={() => {
+                            if (canAdvanceFromPage6) {
+                                setPage(7);
                             }
-                            disabled={!canAdvanceFromPage6}
-                        >
-                            <ImgWithFallback
-                                className="page6-next-btn-img"
-                                sources={
-                                    canAdvanceFromPage6
-                                        ? NEXT_ON_BUTTON_SOURCES
-                                        : NEXT_OFF_BUTTON_SOURCES
-                                }
-                                alt="다음"
-                            />
-                            <ImgWithFallback
-                                className="page6-next-text"
-                                sources={NEXT_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
-                    </div>
-                )
+                        }}
+                        aria-label="다음 페이지"
+                        title={
+                            canAdvanceFromPage6
+                                ? "다음 페이지로 이동"
+                                : "선택지를 고르면 다음으로 이동할 수 있습니다"
+                        }
+                        disabled={!canAdvanceFromPage6}
+                    >
+                        <ImgWithFallback
+                            className="page6-next-btn-img"
+                            sources={
+                                canAdvanceFromPage6
+                                    ? NEXT_ON_BUTTON_SOURCES
+                                    : NEXT_OFF_BUTTON_SOURCES
+                            }
+                            alt="다음"
+                        />
+                        <ImgWithFallback
+                            className="page6-next-text"
+                            sources={NEXT_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
             )
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 7) {
-        return renderPhoneStage(
-            renderQuestionLayout(
-                "page7",
-                <>
+        const { page: pageContent, nav } = renderQuestionLayout(
+            "page7",
+            <>
                     <ImgWithFallback
                         className="page7-q5-title"
                         sources={Q5_TITLE_SOURCES}
@@ -1818,6 +2035,8 @@ export default function App() {
                                 }%`;
                             }
 
+                            const otherInputStyle = { ...labelStyle };
+
                             return (
                                 <div
                                     key={option.id}
@@ -1830,7 +2049,12 @@ export default function App() {
                                     <button
                                         type="button"
                                         className="page7-q5-option-button"
-                                        onClick={() => setQ5Answer(option.id)}
+                                        onClick={() =>
+                                            handleSelectQ5Option(
+                                                option.id,
+                                                option.allowsCustomInput ?? false
+                                            )
+                                        }
                                         onKeyDown={(event) =>
                                             handleQ5KeyDown(event, index)
                                         }
@@ -1857,6 +2081,36 @@ export default function App() {
                                             style={labelStyle}
                                         />
                                     </button>
+                                    {option.allowsCustomInput && isSelected ? (
+                                        <label
+                                            className="option-other-input page7-q5-other-input"
+                                            style={otherInputStyle}
+                                            htmlFor="page7-q5-other"
+                                        >
+                                            <span className="sr-only">
+                                                기타 의견 입력
+                                            </span>
+                                            <ImgWithFallback
+                                                className="option-other-input-bg"
+                                                sources={EMAIL_TEXT_BOX_SOURCES}
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
+                                            <input
+                                                id="page7-q5-other"
+                                                ref={q5OtherInputRef}
+                                                className="option-other-input-field"
+                                                type="text"
+                                                value={q5OtherText}
+                                                onChange={(event) =>
+                                                    setQ5OtherText(
+                                                        event.target.value
+                                                    )
+                                                }
+                                                placeholder="직접 입력"
+                                            />
+                                        </label>
+                                    ) : null}
                                 </div>
                             );
                         })}
@@ -1885,48 +2139,48 @@ export default function App() {
                         </div>
                     ) : null}
                 </>,
-                <>
-                    <div className="page-bottom-nav">
-                        <button
-                            className="img-btn page7-done-btn"
-                            type="button"
-                            onClick={handleSubmitSurvey}
-                            aria-label="설문 완료"
-                            title={
-                                submitting
-                                    ? "설문을 저장하는 중입니다"
-                                    : canAdvanceFromPage7
-                                        ? "설문을 완료합니다"
-                                        : "선택지를 고르면 설문을 완료할 수 있습니다"
+            <>
+                <div className="page-bottom-nav">
+                    <button
+                        className="img-btn page7-done-btn"
+                        type="button"
+                        onClick={handleSubmitSurvey}
+                        aria-label="설문 완료"
+                        title={
+                            submitting
+                                ? "설문을 저장하는 중입니다"
+                                : canAdvanceFromPage7
+                                    ? "설문을 완료합니다"
+                                    : "선택지를 고르면 설문을 완료할 수 있습니다"
+                        }
+                        aria-busy={submitting ? true : undefined}
+                        disabled={!canAdvanceFromPage7 || submitting}
+                    >
+                        <ImgWithFallback
+                            className="page7-done-btn-img"
+                            sources={
+                                canAdvanceFromPage7 && !submitting
+                                    ? DONE_BUTTON_SOURCES
+                                    : DONE_OFF_BUTTON_SOURCES
                             }
-                            aria-busy={submitting ? true : undefined}
-                            disabled={!canAdvanceFromPage7 || submitting}
-                        >
-                            <ImgWithFallback
-                                className="page7-done-btn-img"
-                                sources={
-                                    canAdvanceFromPage7 && !submitting
-                                        ? DONE_BUTTON_SOURCES
-                                        : DONE_OFF_BUTTON_SOURCES
-                                }
-                                alt="완료"
-                            />
-                            <ImgWithFallback
-                                className="page7-done-text"
-                                sources={DONE_TEXT_SOURCES}
-                                alt=""
-                                aria-hidden="true"
-                            />
-                        </button>
+                            alt="완료"
+                        />
+                        <ImgWithFallback
+                            className="page7-done-text"
+                            sources={DONE_TEXT_SOURCES}
+                            alt=""
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
+                {submitting ? (
+                    <div className="sr-only" aria-live="polite">
+                        설문을 저장하는 중입니다.
                     </div>
-                    {submitting ? (
-                        <div className="sr-only" aria-live="polite">
-                            설문을 저장하는 중입니다.
-                        </div>
-                    ) : null}
-                </>
-            )
+                ) : null}
+            </>
         );
+        return renderPhoneStage(pageContent, nav);
     }
 
     if (page === 8) {

--- a/src/constants/surveyContent.js
+++ b/src/constants/surveyContent.js
@@ -105,13 +105,14 @@ export const Q1_OPTIONS = [
         imageSources: ["/could_be_better_image.png"],
     },
     {
-        id: "notMyThing",
-        label: "Not my thing",
-        imageSources: ["/not_my_thing_image.png"],
+        id: "other",
+        label: "Other",
+        imageSources: ["/other_text_image.png"],
+        allowsCustomInput: true,
     },
 ];
 
-export const Q1_OPTION_BASE_TOP_PERCENT = (265 / 812) * 100;
+export const Q1_OPTION_BASE_TOP_PERCENT = (219 / 812) * 100;
 export const Q1_OPTION_STEP_PERCENT = (82 / 812) * 100;
 
 export const Q2_OPTIONS = [
@@ -119,17 +120,17 @@ export const Q2_OPTIONS = [
         id: "interactivity",
         label: "The interactivity",
         imageSources: ["/the_interactivity_image.png"],
-        top: 268,
+        top: 219,
         height: 100,
         toggleTop: 30,
-        labelTop: 0,
+        labelTop: 30,
         labelHeight: 84,
     },
     {
         id: "awesomeGraphics",
         label: "The awesome graphics",
         imageSources: ["/the_awesome_graphics_image.png"],
-        top: 368,
+        top: 319,
         height: 76,
         toggleTop: 18,
         labelTop: 0,
@@ -139,7 +140,7 @@ export const Q2_OPTIONS = [
         id: "funStorytelling",
         label: "The fun storytelling",
         imageSources: ["/the_fun_storytelling_image.png"],
-        top: 444,
+        top: 395,
         height: 76,
         toggleTop: 18,
         labelTop: 0,
@@ -149,7 +150,7 @@ export const Q2_OPTIONS = [
         id: "koreanBackstreet",
         label: "Korean backstreet",
         imageSources: ["/korean_backstreet_image.png"],
-        top: 520,
+        top: 471,
         height: 76,
         toggleTop: 18,
         labelTop: 0,
@@ -159,7 +160,7 @@ export const Q2_OPTIONS = [
         id: "other",
         label: "Other",
         imageSources: ["/other_text_image.png"],
-        top: 596,
+        top: 547,
         height: 76,
         toggleTop: 18,
         labelTop: 0,
@@ -177,32 +178,12 @@ export const Q2_TOGGLE_WIDTH_PERCENT = (Q2_TOGGLE_IMAGE_SIZE / Q2_OPTION_WIDTH) 
 
 export const Q3_OPTIONS = [
     {
-        id: "fashion",
-        label: "Fashion",
-        imageSources: ["/Fashion_image.png"],
-        top: 264,
-        height: 74,
-        toggleTop: 30,
-        labelTop: 0,
-        labelHeight: 60,
-    },
-    {
-        id: "sports",
-        label: "Sports",
-        imageSources: ["/sports_image.png"],
-        top: 338,
-        height: 74,
-        toggleTop: 30,
-        labelTop: 0,
-        labelHeight: 60,
-    },
-    {
         id: "anime",
         label: "Anime",
         imageSources: ["/anime_image.png"],
-        top: 412,
+        top: 219,
         height: 94,
-        toggleTop: 30,
+        toggleTop: 38,
         labelTop: 0,
         labelHeight: 80,
     },
@@ -210,9 +191,9 @@ export const Q3_OPTIONS = [
         id: "movie",
         label: "Movie",
         imageSources: ["/movie_image.png"],
-        top: 506,
+        top: 313,
         height: 74,
-        toggleTop: 30,
+        toggleTop: 18,
         labelTop: 0,
         labelHeight: 60,
     },
@@ -220,11 +201,32 @@ export const Q3_OPTIONS = [
         id: "education",
         label: "Education",
         imageSources: ["/education_image.png"],
-        top: 580,
-        height: 73,
-        toggleTop: 30,
+        top: 387,
+        height: 87,
+        toggleTop: 24.5,
         labelTop: 0,
         labelHeight: 73,
+    },
+    {
+        id: "sports",
+        label: "Sports",
+        imageSources: ["/sports_image.png"],
+        top: 474,
+        height: 74,
+        toggleTop: 30,
+        labelTop: 0,
+        labelHeight: 60,
+    },
+    {
+        id: "other",
+        label: "Other",
+        imageSources: ["/other_text_image.png"],
+        top: 548,
+        height: 74,
+        toggleTop: 30,
+        labelTop: 0,
+        labelHeight: 60,
+        allowsCustomInput: true,
     },
 ];
 
@@ -297,14 +299,15 @@ export const Q4_OPTIONS = [
         top: 246,
     },
     {
-        id: "iDontKnow",
-        label: "I don't know",
-        imageSources: ["/i_dont.png"],
+        id: "other",
+        label: "Other",
+        imageSources: ["/other_text_image.png"],
         top: 328,
+        allowsCustomInput: true,
     },
 ];
 
-export const Q4_OPTIONS_CONTAINER_HEIGHT = 376;
+export const Q4_OPTIONS_CONTAINER_HEIGHT = 410;
 
 export const Q5_OPTION_WIDTH = 323;
 export const Q5_OPTIONS = [
@@ -345,12 +348,13 @@ export const Q5_OPTIONS = [
         toggleTop: 18,
     },
     {
-        id: "tooMuchEffort",
-        label: "Too much effort",
-        imageSources: ["/too_much_effort.png"],
+        id: "other",
+        label: "Other",
+        imageSources: ["/other_text_image.png"],
         top: 326,
         height: 60,
         toggleTop: 18,
+        allowsCustomInput: true,
     },
 ];
 


### PR DESCRIPTION
## Summary
- align the entry page buttons, arrow, and reveal animations to the updated viewport coordinates while keeping the nav fixed
- add state, handlers, and overlays so every Other option reveals an input and is submitted with the response payload
- refresh survey content constants to match the new asset positions and replace legacy choices with the latest images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f421eca88322baa6864c42090420